### PR TITLE
Oemc 24 sort by date

### DIFF
--- a/e2e/sort.spec.ts
+++ b/e2e/sort.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-// import { orderBy } from 'lodash-es';
+import { orderBy } from 'lodash-es';
 
 import type { Geostory } from '@/types/geostories';
 import type { Monitor } from '@/types/monitors';
@@ -33,27 +33,27 @@ test.describe('sort monitors and geostories', () => {
   //   expect(sortedByIdResponse).toEqual([...orderedMonitorsById, ...orderedGeostoriesById]);
   // }); TO - DO - fix when API gets ready
 
-  // test('sort by date', async ({ page }) => {
-  //   const response = await page.waitForResponse(
-  //     'https://api.earthmonitor.org/monitors-and-geostories?sort_by=title'
-  //   );
+  test('sort by date', async ({ page }) => {
+    const response = await page.waitForResponse(
+      'https://api.earthmonitor.org/monitors-and-geostories?sort_by=title'
+    );
 
-  //   const defaultOrderedDataByTitle = (await response.json()) as MonitorsAndGeostoriesResponse[];
-  //   const sortByDateCheckbox = page.getByTestId('date-button');
+    const defaultOrderedDataByTitle = (await response.json()) as MonitorsAndGeostoriesResponse[];
+    const sortByDateCheckbox = page.getByTestId('date-button');
 
-  //   await sortByDateCheckbox.click();
-  //   const sortPromise = page.waitForResponse(
-  //     'https://api.earthmonitor.org/monitors-and-geostories?sort_by=date'
-  //   );
-  //   const sortedResponse = await sortPromise;
-  //   const sortedByDateResponse = (await sortedResponse.json()) as MonitorsAndGeostoriesResponse[];
+    await sortByDateCheckbox.click();
+    const sortPromise = page.waitForResponse(
+      'https://api.earthmonitor.org/monitors-and-geostories?sort_by=date'
+    );
+    const sortedResponse = await sortPromise;
+    const sortedByDateResponse = (await sortedResponse.json()) as MonitorsAndGeostoriesResponse[];
 
-  //   const monitors = defaultOrderedDataByTitle.filter((item) => item.geostories);
-  //   const geostories = defaultOrderedDataByTitle.filter((item) => item.layers);
-  //   const orderedMonitorsByDate = orderBy(monitors, ['date']) satisfies Monitor[];
-  //   const orderedGeostoriesByDate = orderBy(geostories, ['date']) satisfies Geostory[];
-  //   expect(sortedByDateResponse).toEqual([...orderedMonitorsByDate, ...orderedGeostoriesByDate]);
-  // }); TO - DO - fix when API gets ready
+    const monitors = defaultOrderedDataByTitle.filter((item) => item.geostories);
+    const geostories = defaultOrderedDataByTitle.filter((item) => item.layers);
+    const orderedMonitorsByDate = orderBy(monitors, ['date']) satisfies Monitor[];
+    const orderedGeostoriesByDate = orderBy(geostories, ['date']) satisfies Geostory[];
+    expect(sortedByDateResponse).toEqual([...orderedMonitorsByDate, ...orderedGeostoriesByDate]);
+  });
 
   test('sort by title (default option)', async ({ page }) => {
     const response = await page.waitForResponse(

--- a/src/components/datasets-grid/constants/index.ts
+++ b/src/components/datasets-grid/constants/index.ts
@@ -1,9 +1,6 @@
 import type { SortingCriteria, Theme } from '../types';
 
-export const SORTING = [
-  'title',
-  //  'date' TO - Do add sorting by date when API gets ready
-] satisfies SortingCriteria[];
+export const SORTING = ['title', 'date'] satisfies SortingCriteria[];
 export const THEMES = [
   'Water',
   'Agriculture',

--- a/src/components/datasets-grid/index.tsx
+++ b/src/components/datasets-grid/index.tsx
@@ -184,7 +184,7 @@ const LandingDatasets = () => {
                   className="flex w-full flex-1 font-inter font-medium"
                   onValueChange={handleSortingCriteria}
                 >
-                  <div className="align-left flex flex-col justify-start space-y-2">
+                  <div className="align-left flex flex-col justify-start space-y-4">
                     {SORTING.map((sort) => (
                       <div
                         key={sort}

--- a/src/components/datasets-grid/types.d.ts
+++ b/src/components/datasets-grid/types.d.ts
@@ -1,5 +1,4 @@
-export type SortingCriteria = 'title';
-// | 'date' TO - DO: add date sorting when API gets readdy
+export type SortingCriteria = 'title' | 'date';
 export type Theme =
   | 'Water'
   | 'Agriculture'

--- a/src/components/ui/dropdown.tsx
+++ b/src/components/ui/dropdown.tsx
@@ -60,10 +60,11 @@ const DropdownMenuContent = forwardRef<
     <DropdownMenuPrimitive.Content
       ref={ref}
       sideOffset={sideOffset}
-      className={cn(
-        'dropdown-menu-content z-50 w-full overflow-hidden border border-secondary-900 p-1 text-popover-foreground text-secondary-700 shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
-        className
-      )}
+      className={cn({
+        'dropdown-menu-content z-50 w-full overflow-hidden border border-secondary-900 bg-brand-500 p-1 text-popover-foreground text-secondary-700 shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2':
+          true,
+        [className]: !!className,
+      })}
       {...props}
     />
   </DropdownMenuPrimitive.Portal>


### PR DESCRIPTION
## Sorting monitors and geo stories

### Overview

_Date added as a sorting criteria, currently not working because is not dorting from API._

### Designs

_[Link to the related design prototypes (if applicable)](https://www.figma.com/file/Xz2WD4UWH3R6OdmeqmAMbF/%E2%9C%85-Open-Earth-Monitor---Prototype-%5BInternal%5D---September?node-id=123%3A4615&mode=dev)_

### Testing instructions

_PChnage sort criteria for monitors and geo stories in the landing page._

### Feature relevant tickets

_[Link to the related task manager tickets](https://vizzuality.atlassian.net/jira/software/c/projects/OEMC/boards/95?selectedIssue=OEMC-24&atlOrigin=eyJpIjoiMzM0YzhiMzk2NGRlNGMzOWIzMjIyYzg3ODEyOTM5M2QiLCJwIjoiaiJ9)_

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] Update CHANGELOG
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist 

