### PR TITLE
Oemc 132 fix/back to monitor

### DIFF
--- a/src/app/map/geostories/[geostory_id]/page.tsx
+++ b/src/app/map/geostories/[geostory_id]/page.tsx
@@ -16,15 +16,17 @@ import DatasetCard from '@/components/datasets/card';
 import GeostoryHead from '@/components/geostories/header';
 import Loading from '@/components/loading';
 
+const findMonitorByGeoStoryId = (monitors: MonitorParsed[], geoStoryId: string) =>
+  monitors?.find((monitor) =>
+    monitor.geostories.some((geostory) => geostory.id === geoStoryId)
+  ) satisfies MonitorParsed;
+
 const GeostoryPage: NextPage<{ params: { geostory_id: string } }> = ({
   params: { geostory_id },
 }) => {
   const { data, isLoading, isFetched, isError } = useGeostoryLayers({ geostory_id });
   const { data: monitors } = useMonitors();
-  const monitor = useMemo<MonitorParsed>(
-    () => monitors?.find(({ geostories }) => geostories.map(({ id }) => id === geostory_id)),
-    [monitors, geostory_id]
-  );
+  const monitor = findMonitorByGeoStoryId(monitors, geostory_id);
 
   const { title: monitorTitle, id: monitorId, color } = monitor || {};
 


### PR DESCRIPTION
## Bug fix

### Overview

_Fix function to go back from a geo story to the monitor it belongs to._

### Testing instructions

_nevigate to /map/geostories/[geostory_id]_

### Feature relevant tickets

_[Link to relevant ticket](https://vizzuality.atlassian.net/browse/OEMC-132?atlOrigin=eyJpIjoiYWRlMDI5OTdiNjU3NDZkYWFiYTZlZjcxNjVjNDE3ZGYiLCJwIjoiaiJ9)_

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] Update CHANGELOG
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist 

