### PR TITLE
dropdown styles

### DIFF
--- a/src/components/map/attributions/index.tsx
+++ b/src/components/map/attributions/index.tsx
@@ -20,7 +20,7 @@ import type { ControlsProps } from './types';
 
 type ControlsPropsWithChildren = PropsWithChildren<ControlsProps>;
 const ATTRIBUTION_STYLES =
-  'cursor-pointer text-5xl text-[10px] text-secondary-500 shadow-brand-500 drop-shadow-[2px_2px_2px_var(--tw-shadow-color)]';
+  'cursor-pointer text-5xl text-[10px] text-secondary-500 shadow-brand-500 drop-shadow-[2px_2px_2px_var(--tw-shadow-color)] whitespace-nowrap';
 export const Controls: FC<ControlsPropsWithChildren> = ({
   className = 'absolute bottom-3 space-x-4',
 }: ControlsPropsWithChildren) => (

--- a/src/components/map/legend/constants.ts
+++ b/src/components/map/legend/constants.ts
@@ -1,4 +1,7 @@
 export const DROPDOWN_TRIGGER_STYLES = 'w-full border-none px-3.5 py-2.5';
-export const DROPDOWN_CONTENT_STYLES = 'z-[60] max-h-56 w-full overflow-y-auto bg-brand-500';
+export const DROPDOWN_CONTENT_STYLES = 'dropdown-menu-content z-[60] w-full bg-brand-500 px-0';
+export const DROPDOWN_ITEM_STYLES =
+  'm-auto flex w-full flex-1 justify-center whitespace-nowrap py-0 px-2 text-center text-secondary-500 ';
+
 export const LEGEND_BUTTON_STYLES =
   'bg-brand-500 flex-1 text-center text-xs uppercase font-medium grow px-2 h-[34px] py-1 text-white hover:bg-secondary-500 hover:text-brand-500 disabled:opacity-50 disabled:cursor-not-allowed';

--- a/src/components/map/legend/constants.ts
+++ b/src/components/map/legend/constants.ts
@@ -1,0 +1,4 @@
+export const DROPDOWN_TRIGGER_STYLES = 'w-full border-none px-3.5 py-2.5';
+export const DROPDOWN_CONTENT_STYLES = 'z-[60] max-h-56 w-full overflow-y-auto bg-brand-500';
+export const LEGEND_BUTTON_STYLES =
+  'bg-brand-500 flex-1 text-center text-xs uppercase font-medium grow px-2 h-[34px] py-1 text-white hover:bg-secondary-500 hover:text-brand-500 disabled:opacity-50 disabled:cursor-not-allowed';

--- a/src/components/map/legend/index.tsx
+++ b/src/components/map/legend/index.tsx
@@ -11,12 +11,14 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
 } from '@/components/ui/dropdown';
+import { ScrollArea } from '@/components/ui/scroll-area';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 
 import {
   DROPDOWN_TRIGGER_STYLES,
   LEGEND_BUTTON_STYLES,
   DROPDOWN_CONTENT_STYLES,
+  DROPDOWN_ITEM_STYLES,
 } from './constants';
 import OpacitySetting from './opacity';
 import RemoveLayer from './remove';
@@ -166,18 +168,21 @@ export const Legend = () => {
                   alignOffset={0}
                   sideOffset={0}
                   className={DROPDOWN_CONTENT_STYLES}
-                  style={{ width: 'calc(100% - 2rem)' }}
                 >
-                  {range?.map((d) => (
-                    <DropdownMenuItem
-                      key={d.value}
-                      className="m-auto flex w-full flex-1 justify-center whitespace-nowrap px-6 text-center text-secondary-500 hover:bg-secondary-900"
-                    >
-                      <button type="button" value={d.value} onClick={handleBaseDate}>
-                        {d.label}
-                      </button>
-                    </DropdownMenuItem>
-                  ))}
+                  <ScrollArea className="max-h-[200px] w-full">
+                    {range?.map((d) => (
+                      <DropdownMenuItem key={d.value} className={DROPDOWN_ITEM_STYLES}>
+                        <button
+                          type="button"
+                          value={d.value}
+                          onClick={handleBaseDate}
+                          className="rounded-sm px-2.5 py-1 hover:bg-secondary-900"
+                        >
+                          {d.label}
+                        </button>
+                      </DropdownMenuItem>
+                    ))}
+                  </ScrollArea>
                 </DropdownMenuContent>
               </DropdownMenu>
               <DropdownMenu>
@@ -191,18 +196,21 @@ export const Legend = () => {
                   alignOffset={0}
                   sideOffset={0}
                   className={DROPDOWN_CONTENT_STYLES}
-                  style={{ width: 'calc(100% - 2rem)' }}
                 >
-                  {range?.map((d) => (
-                    <DropdownMenuItem
-                      key={d.value}
-                      className="m-auto flex w-full flex-1 justify-center whitespace-nowrap px-6 text-center text-secondary-500 hover:bg-secondary-900"
-                    >
-                      <button type="button" value={d.value} onClick={handleCompareDate}>
-                        {d.label}
-                      </button>
-                    </DropdownMenuItem>
-                  ))}
+                  <ScrollArea className="max-h-[200px] w-full">
+                    {range?.map((d) => (
+                      <DropdownMenuItem key={d.value} className={DROPDOWN_ITEM_STYLES}>
+                        <button
+                          type="button"
+                          value={d.value}
+                          onClick={handleCompareDate}
+                          className="rounded-sm px-2.5 py-1 hover:bg-secondary-900"
+                        >
+                          {d.label}
+                        </button>
+                      </DropdownMenuItem>
+                    ))}
+                  </ScrollArea>
                 </DropdownMenuContent>
               </DropdownMenu>
             </div>

--- a/src/components/map/legend/index.tsx
+++ b/src/components/map/legend/index.tsx
@@ -13,14 +13,16 @@ import {
 } from '@/components/ui/dropdown';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 
+import {
+  DROPDOWN_TRIGGER_STYLES,
+  LEGEND_BUTTON_STYLES,
+  DROPDOWN_CONTENT_STYLES,
+} from './constants';
 import OpacitySetting from './opacity';
 import RemoveLayer from './remove';
 import LayerVisibility from './visibility';
 
 type ActiveTab = 'layer-settings' | 'compare-layers';
-
-const LEGEND_BUTTON_STYLES =
-  'bg-brand-500 flex-1 text-center text-xs uppercase font-medium grow px-2 h-[34px] py-1 text-white hover:bg-secondary-500 hover:text-brand-500 disabled:opacity-50 disabled:cursor-not-allowed';
 
 const findLabel = (value: string, range: { label: string; value: string | number }[]) =>
   range?.find((d: { label: string; value: string }) => d.value === value)?.label satisfies
@@ -93,7 +95,7 @@ export const Legend = () => {
 
   return (
     <div
-      className="absolute bottom-3 right-3 z-10 space-y-1 font-inter text-xs"
+      className="absolute bottom-3 right-3 z-[55] space-y-1 font-inter text-xs"
       data-testid="map-legend"
     >
       <Tabs value={activeTab} onValueChange={handleTabChange} className="min-w-[270px]">
@@ -154,7 +156,7 @@ export const Legend = () => {
 
             <div className="flex w-full flex-col items-start">
               <DropdownMenu>
-                <DropdownMenuTrigger className="w-full border-none px-3.5 py-2.5">
+                <DropdownMenuTrigger className={DROPDOWN_TRIGGER_STYLES}>
                   <div className="flex w-full justify-between whitespace-nowrap ">
                     <span>Selected year: {baseDateLabel}</span>
                   </div>
@@ -163,7 +165,7 @@ export const Legend = () => {
                   align="start"
                   alignOffset={0}
                   sideOffset={0}
-                  className="max-h-56 w-full bg-brand-500"
+                  className={DROPDOWN_CONTENT_STYLES}
                   style={{ width: 'calc(100% - 2rem)' }}
                 >
                   {range?.map((d) => (
@@ -179,7 +181,7 @@ export const Legend = () => {
                 </DropdownMenuContent>
               </DropdownMenu>
               <DropdownMenu>
-                <DropdownMenuTrigger className="flex w-full border-none px-3.5 py-2.5">
+                <DropdownMenuTrigger className={DROPDOWN_TRIGGER_STYLES}>
                   <div className="flex w-full justify-between whitespace-nowrap">
                     <span>Selected year: {CompareDateLabel}</span>
                   </div>
@@ -188,7 +190,7 @@ export const Legend = () => {
                   align="start"
                   alignOffset={0}
                   sideOffset={0}
-                  className="max-h-56 w-full bg-brand-500"
+                  className={DROPDOWN_CONTENT_STYLES}
                   style={{ width: 'calc(100% - 2rem)' }}
                 >
                   {range?.map((d) => (

--- a/src/components/map/legend/index.tsx
+++ b/src/components/map/legend/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, createRef, useLayoutEffect } from 'react';
 
 import { cn } from '@/lib/classnames';
 
@@ -20,7 +20,7 @@ import LayerVisibility from './visibility';
 type ActiveTab = 'layer-settings' | 'compare-layers';
 
 const LEGEND_BUTTON_STYLES =
-  'bg-brand-500 flex-1 text-center text-xs uppercase rounded font-medium grow px-2 h-[34px] py-1 tracking-wide text-white hover:bg-secondary-500 hover:text-brand-500 disabled:opacity-50 disabled:cursor-not-allowed';
+  'bg-brand-500 flex-1 text-center text-xs uppercase font-medium grow px-2 h-[34px] py-1 text-white hover:bg-secondary-500 hover:text-brand-500 disabled:opacity-50 disabled:cursor-not-allowed';
 
 const findLabel = (value: string, range: { label: string; value: string | number }[]) =>
   range?.find((d: { label: string; value: string }) => d.value === value)?.label satisfies
@@ -80,6 +80,16 @@ export const Legend = () => {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [compareDate]);
+  const [legendWidth, setLegendWith] = useState<number>(0);
+
+  const titleRef = createRef<HTMLDivElement>();
+
+  useLayoutEffect(() => {
+    if (titleRef && titleRef.current) {
+      const width = titleRef.current.clientWidth;
+      setLegendWith(width);
+    }
+  }, [titleRef, setLegendWith]);
 
   return (
     <div
@@ -87,7 +97,7 @@ export const Legend = () => {
       data-testid="map-legend"
     >
       <Tabs value={activeTab} onValueChange={handleTabChange} className="min-w-[270px]">
-        <TabsList className="border-box rounded border border-secondary-500">
+        <TabsList className="border border-secondary-500 bg-brand-500">
           <TabsTrigger
             data-testid="map-legend-toggle-button"
             value="layer-settings"
@@ -104,16 +114,20 @@ export const Legend = () => {
             Compare
           </TabsTrigger>
         </TabsList>
-        <TabsContent value="layer-settings">
+        <TabsContent value="layer-settings" style={{ minWidth: legendWidth + 130 }}>
           <div
-            className="relative flex min-h-[34px] items-start justify-between space-x-4 rounded-sm border border-gray-600 bg-brand-500 px-4 py-3 text-secondary-500"
+            className="relative flex min-h-[34px] items-start justify-between space-x-4 rounded-sm border border-gray-600 bg-brand-500 px-3.5 py-2.5 text-secondary-500"
             data-testid="map-legend-item"
           >
-            <div data-testid="map-legend-item-title" className="text-xs font-bold">
+            <div
+              data-testid="map-legend-item-title"
+              className="rounded-sm text-xs font-bold"
+              ref={titleRef}
+            >
               {title}
             </div>
             <div
-              className="flex space-x-2 divide-x divide-secondary-900"
+              className="flex space-x-2 divide-x divide-secondary-800"
               data-testid="map-legend-item-toolbar"
             >
               <div className="flex space-x-2">
@@ -124,33 +138,40 @@ export const Legend = () => {
             </div>
           </div>
         </TabsContent>
-        <TabsContent value="compare-layers" className="ml-0">
+        <TabsContent value="compare-layers" style={{ minWidth: legendWidth + 130 }}>
           <div
             className={cn(
-              'relative flex min-h-[34px] w-full flex-col justify-between space-y-6 rounded-sm border border-gray-600 bg-brand-500 px-4 py-3 text-secondary-500'
+              'relative flex min-h-[34px] w-full flex-col justify-between rounded-sm border border-gray-600 bg-brand-500 text-secondary-500'
             )}
             data-testid="map-legend-item"
           >
-            <div data-testid="map-legend-item-title" className="text-xs font-bold">
+            <div
+              data-testid="map-legend-item-title"
+              className="rounded-sm px-3.5 py-2.5 text-xs font-bold"
+            >
               {title}
             </div>
 
-            <div className="flex w-full flex-col items-start space-y-6 ">
+            <div className="flex w-full flex-col items-start">
               <DropdownMenu>
-                <DropdownMenuTrigger className="w-full border-none p-0">
-                  <div className="flex w-full justify-between">
+                <DropdownMenuTrigger className="w-full border-none px-3.5 py-2.5">
+                  <div className="flex w-full justify-between whitespace-nowrap ">
                     <span>Selected year: {baseDateLabel}</span>
                   </div>
                 </DropdownMenuTrigger>
-                <DropdownMenuContent className="w-full bg-brand-500">
+                <DropdownMenuContent
+                  align="start"
+                  alignOffset={0}
+                  sideOffset={0}
+                  className="max-h-56 w-full bg-brand-500"
+                  style={{ width: 'calc(100% - 2rem)' }}
+                >
                   {range?.map((d) => (
-                    <DropdownMenuItem key={d.value}>
-                      <button
-                        type="button"
-                        value={d.value}
-                        onClick={handleBaseDate}
-                        className="w-full"
-                      >
+                    <DropdownMenuItem
+                      key={d.value}
+                      className="m-auto flex w-full flex-1 justify-center whitespace-nowrap px-6 text-center text-secondary-500 hover:bg-secondary-900"
+                    >
+                      <button type="button" value={d.value} onClick={handleBaseDate}>
                         {d.label}
                       </button>
                     </DropdownMenuItem>
@@ -158,20 +179,24 @@ export const Legend = () => {
                 </DropdownMenuContent>
               </DropdownMenu>
               <DropdownMenu>
-                <DropdownMenuTrigger className="w-full border-none p-0">
-                  <div className="flex w-full justify-between">
+                <DropdownMenuTrigger className="flex w-full border-none px-3.5 py-2.5">
+                  <div className="flex w-full justify-between whitespace-nowrap">
                     <span>Selected year: {CompareDateLabel}</span>
                   </div>
                 </DropdownMenuTrigger>
-                <DropdownMenuContent className="max-w-[100px] bg-brand-500">
+                <DropdownMenuContent
+                  align="start"
+                  alignOffset={0}
+                  sideOffset={0}
+                  className="max-h-56 w-full bg-brand-500"
+                  style={{ width: 'calc(100% - 2rem)' }}
+                >
                   {range?.map((d) => (
-                    <DropdownMenuItem key={d.value}>
-                      <button
-                        type="button"
-                        value={d.value}
-                        onClick={handleCompareDate}
-                        className="w-full"
-                      >
+                    <DropdownMenuItem
+                      key={d.value}
+                      className="m-auto flex w-full flex-1 justify-center whitespace-nowrap px-6 text-center text-secondary-500 hover:bg-secondary-900"
+                    >
+                      <button type="button" value={d.value} onClick={handleCompareDate}>
                         {d.label}
                       </button>
                     </DropdownMenuItem>

--- a/src/components/map/legend/opacity/index.tsx
+++ b/src/components/map/legend/opacity/index.tsx
@@ -11,24 +11,32 @@ import { Popover, PopoverArrow, PopoverContent, PopoverTrigger } from '@/compone
 
 export const OpacitySetting: FC = () => {
   const [layers, setLayers] = useSyncLayersSettings();
+  const [opacityContent, setOpacityContent] = useState<'info' | 'slider'>('info');
   const [isOpacityPopoverOpen, setOpacityPopoverOpen] = useState<boolean>(false);
 
   const layerOpacity = layers?.[0]?.opacity;
   const opacity = !layerOpacity && layerOpacity !== 0 ? 1 : layerOpacity;
 
-  const handleOpacityVisibility = useCallback(
-    () => setOpacityPopoverOpen(!isOpacityPopoverOpen),
-    [isOpacityPopoverOpen]
-  );
+  const handleOpacityVisibility = useCallback(() => {
+    setOpacityPopoverOpen(!isOpacityPopoverOpen);
+  }, [isOpacityPopoverOpen]);
 
   const handleChange = useCallback(
     (e: number[]) => setLayers((prevState) => [{ ...prevState?.[0], opacity: e[0] }]),
     [setLayers]
   );
 
+  const handleMouseLeave = useCallback(() => {
+    setOpacityContent('slider');
+  }, []);
+
+  const handleMouseEnter = useCallback(() => {
+    setOpacityContent('info');
+  }, []);
+
   return (
     <Popover onOpenChange={handleOpacityVisibility}>
-      <PopoverTrigger data-testid="layer-opacity-button">
+      <PopoverTrigger data-testid="layer-opacity-button" onMouseEnter={handleMouseEnter}>
         <MdOutlineOpacity
           className={cn({
             'h-4 w-4 text-gray-600 hover:text-secondary-500': true,
@@ -37,29 +45,36 @@ export const OpacitySetting: FC = () => {
         />
       </PopoverTrigger>
       <PopoverContent
+        onClick={handleMouseLeave}
         sideOffset={0}
         alignOffset={0}
         align="center"
-        className="w-[189px] rounded-3xl border border-secondary-900 p-3"
+        className={cn({
+          'z-[60] w-[189px] rounded-3xl border border-secondary-900 px-3 py-3.5': true,
+          'p2 w-fit py-1': opacityContent === 'info',
+        })}
       >
-        <div className="flex w-full flex-col space-y-2">
-          <div
-            data-testid="slider-current-value"
-            className="m-auto w-[55px] rounded-xl border border-secondary-900 p-3 font-inter text-xs font-medium text-white"
-          >
-            {Math.round(opacity * 100)}%
+        {opacityContent === 'slider' && (
+          <div className="flex w-full flex-col space-y-2">
+            <div
+              data-testid="slider-current-value"
+              className="m-auto w-[55px] rounded-xl border border-secondary-900 px-3 py-2 font-inter text-xs font-medium text-white"
+            >
+              {Math.round(opacity * 100)}%
+            </div>
+            <div className="relative py-1.5">
+              <Slider
+                onValueChange={handleChange}
+                value={[opacity]}
+                min={0}
+                max={1}
+                step={0.01}
+                data-testid="layer-opacity-slider"
+              />
+            </div>
           </div>
-          <div className="relative py-1.5">
-            <Slider
-              onValueChange={handleChange}
-              value={[opacity]}
-              min={0}
-              max={1}
-              step={0.01}
-              data-testid="layer-opacity-slider"
-            />
-          </div>
-        </div>
+        )}
+        {opacityContent === 'info' && <div className="font-medium text-secondary-500">Opacity</div>}
         <PopoverArrow className="text-brand-50" />
       </PopoverContent>
     </Popover>

--- a/src/components/timeseries/index.tsx
+++ b/src/components/timeseries/index.tsx
@@ -9,6 +9,7 @@ import cn from '@/lib/classnames';
 
 import type { LayerDateRange, LayerParsed } from '@/types/layers';
 
+import { ScrollArea } from '@/components/ui/scroll-area';
 import {
   Select,
   SelectContent,
@@ -101,16 +102,18 @@ const TimeSeries: FC<{
                 </>
               </SelectTrigger>
               <SelectContent
-                className="mx-1 flex max-h-56 items-center justify-center p-1 text-center"
+                className="flex max-h-56 w-full min-w-fit items-center text-center"
                 alignOffset={-20}
                 sideOffset={0}
                 style={{ width: 'calc(100% - 2rem)' }}
               >
-                {range.map((r: LayerDateRange) => (
-                  <SelectItem key={r.value} value={r.value}>
-                    {r.label}
-                  </SelectItem>
-                ))}
+                <ScrollArea className="max-h-[200px] w-full">
+                  {range.map((r: LayerDateRange) => (
+                    <SelectItem key={r.value} value={r.value} className="px-2">
+                      <span className="rounded-sm px-2 py-1 hover:bg-secondary-900">{r.label}</span>
+                    </SelectItem>
+                  ))}
+                </ScrollArea>
               </SelectContent>
             </Select>
           )}

--- a/src/components/timeseries/index.tsx
+++ b/src/components/timeseries/index.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import type { FC } from 'react';
 
+import { HiChevronDown } from 'react-icons/hi';
 import { HiPlay, HiPause, HiCalendarDays } from 'react-icons/hi2';
 import { useInterval } from 'usehooks-ts';
 
@@ -12,6 +13,7 @@ import {
   Select,
   SelectContent,
   SelectItem,
+  SelectIcon,
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
@@ -26,6 +28,7 @@ const TimeSeries: FC<{
   autoPlay?: boolean;
   isActive?: boolean;
 }> = ({ range, autoPlay = false, isActive = false, layerId }) => {
+  const [contentVisibility, setContentVisibility] = useState<boolean>(false);
   const [layers, setLayers] = useSyncLayersSettings();
   const [compareLayers, setCompareLayers] = useSyncCompareLayersSettings();
 
@@ -80,11 +83,29 @@ const TimeSeries: FC<{
           <HiCalendarDays className="h-10 w-10" />
           <span className="text-[10px]">DATE:</span>
           {currentRange && (
-            <Select value={currentRange.value} onValueChange={handleSelect} disabled={!isActive}>
+            <Select
+              value={currentRange.value}
+              onValueChange={handleSelect}
+              disabled={!isActive}
+              open={contentVisibility}
+              onOpenChange={() => setContentVisibility(!contentVisibility)}
+            >
               <SelectTrigger className="text-xs font-semibold underline">
-                <SelectValue />
+                <>
+                  <SelectValue />
+                  <SelectIcon className="w-full">
+                    <HiChevronDown
+                      className={cn({ 'h-5 w-5': true, 'rotate-180': contentVisibility })}
+                    />
+                  </SelectIcon>
+                </>
               </SelectTrigger>
-              <SelectContent className="w-fit max-w-fit" alignOffset={-10} sideOffset={0}>
+              <SelectContent
+                className="mx-1 flex max-h-56 items-center justify-center p-1 text-center"
+                alignOffset={-20}
+                sideOffset={0}
+                style={{ width: 'calc(100% - 2rem)' }}
+              >
                 {range.map((r: LayerDateRange) => (
                   <SelectItem key={r.value} value={r.value}>
                     {r.label}

--- a/src/components/ui/dropdown.tsx
+++ b/src/components/ui/dropdown.tsx
@@ -61,7 +61,7 @@ const DropdownMenuContent = forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn({
-        'dropdown-menu-content z-50 w-full overflow-hidden border border-secondary-900 bg-brand-500 p-1 text-popover-foreground text-secondary-700 shadow-md hover:text-secondary-500 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2':
+        'dropdown-menu-trigger z-50 w-full overflow-hidden border border-secondary-900 bg-brand-500 p-1 text-popover-foreground text-secondary-700 shadow-md hover:text-secondary-500 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2':
           true,
         [className]: !!className,
       })}

--- a/src/components/ui/dropdown.tsx
+++ b/src/components/ui/dropdown.tsx
@@ -36,7 +36,7 @@ const DropdownMenuTrigger = forwardRef<
   <DropdownMenuPrimitive.Trigger
     ref={ref}
     className={cn({
-      'group h-full rounded-none border border-secondary-900 px-8 text-secondary-500 hover:bg-secondary-700 hover:text-secondary-500':
+      'group h-full rounded-none border border-secondary-900 px-8 text-secondary-500 hover:bg-secondary-900 hover:text-secondary-500':
         true,
       'pl-8': inset,
       [className]: !!className,
@@ -82,7 +82,7 @@ const DropdownMenuItem = forwardRef<
   <DropdownMenuPrimitive.Item
     ref={ref}
     className={cn({
-      'relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-secondary-700 data-[disabled]:pointer-events-none data-[disabled]:opacity-50':
+      'relative flex cursor-default select-none items-center whitespace-nowrap rounded-sm px-2 py-1.5 text-sm outline-none transition-colors data-[disabled]:pointer-events-none data-[disabled]:opacity-50':
         true,
       'pl-8': inset,
       [className]: !!className,

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -63,10 +63,7 @@ const SelectContent = forwardRef<
       {...props}
     >
       <SelectPrimitive.Viewport
-        className={cn(
-          position === 'popper' &&
-            'h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)] p-1'
-        )}
+        className={cn(position === 'popper' && 'h-[var(--radix-select-trigger-height)] w-full ')}
       >
         {children}
       </SelectPrimitive.Viewport>
@@ -94,7 +91,7 @@ const SelectItem = forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={cn({
-      'relative m-auto flex w-fit cursor-pointer select-none items-center justify-center whitespace-nowrap rounded-sm px-2 py-1.5 text-sm text-secondary-500 outline-none hover:bg-secondary-900 data-[disabled]:pointer-events-none data-[disabled]:opacity-50':
+      'relative m-auto flex w-fit cursor-pointer select-none items-center justify-center whitespace-nowrap rounded-sm px-2 py-1.5 text-sm text-secondary-500 outline-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50':
         true,
       [className]: !!className,
     })}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -3,7 +3,6 @@
 import { forwardRef, ElementRef, ComponentPropsWithoutRef } from 'react';
 
 import * as SelectPrimitive from '@radix-ui/react-select';
-import { HiChevronDown } from 'react-icons/hi';
 
 import { cn } from 'lib/classnames';
 
@@ -20,7 +19,7 @@ const SelectIcon = forwardRef<
   <SelectPrimitive.Icon
     ref={ref}
     className={cn(
-      'flex h-9 w-full items-center justify-between bg-transparent text-sm shadow-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none disabled:cursor-not-allowed disabled:opacity-50',
+      'flex h-9 w-full items-center justify-between bg-transparent text-sm shadow-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 data-[state-open]:rotate-180',
       className
     )}
     {...props}
@@ -38,15 +37,12 @@ const SelectTrigger = forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      'flex h-9 w-full items-center justify-between space-x-2 bg-transparent text-sm shadow-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none disabled:cursor-not-allowed disabled:opacity-50',
+      'flex h-9 w-full items-center justify-between space-x-2 whitespace-nowrap bg-transparent text-sm shadow-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none disabled:cursor-not-allowed disabled:opacity-50',
       className
     )}
     {...props}
   >
     {children}
-    <SelectIcon>
-      <HiChevronDown className="h-5 w-5" />
-    </SelectIcon>
   </SelectPrimitive.Trigger>
 ));
 SelectTrigger.displayName = SelectPrimitive.Trigger.displayName;
@@ -58,20 +54,18 @@ const SelectContent = forwardRef<
   <SelectPrimitive.Portal>
     <SelectPrimitive.Content
       ref={ref}
-      className={cn(
-        'relative z-50 overflow-hidden border border-secondary-900 bg-brand-500 shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
-        position === 'popper' &&
-          'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
-        className
-      )}
+      className={cn({
+        'relative z-50 overflow-hidden border border-secondary-900 bg-brand-500 shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2':
+          true,
+        [className]: !!className,
+      })}
       position={position}
       {...props}
     >
       <SelectPrimitive.Viewport
         className={cn(
-          'p-1',
           position === 'popper' &&
-            'h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]'
+            'h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)] p-1'
         )}
       >
         {children}
@@ -100,7 +94,7 @@ const SelectItem = forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={cn({
-      'relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-2  text-sm outline-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50':
+      'relative m-auto flex w-fit cursor-pointer select-none items-center justify-center whitespace-nowrap rounded-sm px-2 py-1.5 text-sm text-secondary-500 outline-none hover:bg-secondary-900 data-[disabled]:pointer-events-none data-[disabled]:opacity-50':
         true,
       [className]: !!className,
     })}

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -6,7 +6,20 @@ import * as TabsPrimitive from '@radix-ui/react-tabs';
 
 import { cn } from '@/lib/classnames';
 
-const Tabs = TabsPrimitive.Root;
+const Tabs = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Root
+    ref={ref}
+    className={cn({
+      'rounded-sm': true,
+      [className]: !!className,
+    })}
+    {...props}
+  />
+));
+Tabs.displayName = TabsPrimitive.Root.displayName;
 
 const TabsList = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.List>,
@@ -15,7 +28,7 @@ const TabsList = React.forwardRef<
   <TabsPrimitive.List
     ref={ref}
     className={cn({
-      'inline-flex w-full items-center justify-start': true,
+      'inline-flex w-full items-center justify-start rounded-sm': true,
       [className]: !!className,
     })}
     {...props}
@@ -30,7 +43,7 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      'inline-flex items-center justify-center whitespace-nowrap px-7.5 py-5 text-xs font-medium uppercase tracking-wide text-secondary-500 ring-offset-background transition-all hover:bg-brand-50 hover:bg-secondary-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-secondary-500 data-[state=active]:text-brand-500',
+      'inline-flex items-center justify-center overflow-hidden whitespace-nowrap px-3.5 py-2.5 text-xs font-medium uppercase tracking-[0.96px] text-secondary-500 ring-offset-background transition-all hover:bg-brand-50 hover:bg-secondary-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:border-secondary-500 data-[state=active]:bg-secondary-500 data-[state=active]:text-brand-500',
       className
     )}
     {...props}
@@ -45,7 +58,7 @@ const TabsContent = React.forwardRef<
   <TabsPrimitive.Content
     ref={ref}
     className={cn({
-      'ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2':
+      'mt-1 box-content rounded-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2':
         true,
       [className]: !!className,
     })}

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -43,7 +43,7 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      'inline-flex items-center justify-center overflow-hidden whitespace-nowrap px-3.5 py-2.5 text-xs font-medium uppercase tracking-[0.96px] text-secondary-500 ring-offset-background transition-all hover:bg-brand-50 hover:bg-secondary-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:border-secondary-500 data-[state=active]:bg-secondary-500 data-[state=active]:text-brand-500',
+      'inline-flex items-center justify-center overflow-hidden whitespace-nowrap rounded-sm px-3.5 py-2.5 text-xs font-medium uppercase tracking-[0.96px] text-secondary-500 ring-offset-background transition-all hover:bg-brand-50 hover:bg-secondary-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:border-secondary-500 data-[state=active]:bg-secondary-500 data-[state=active]:text-brand-500',
       className
     )}
     {...props}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -113,8 +113,12 @@
   }
 }
 
+.dropdown-menu-trigger {
+  width: var(--radix-dropdown-menu-trigger-width);
+}
+
 .dropdown-menu-content {
-  width: var(--radix-dropdown-menu-trigger-width) 
+  width: var(--radix-dropdown-menu-content-transform-origin);
 }
 
 .visually-hidden {


### PR DESCRIPTION
## SUnify styles in dates dropdowns

### Overview

_The dropdown in the map page to display dates should have the same styles as the dropdown in the legend._

### Designs

_N/A_

### Testing instructions

_Go to the map, select a monitor, and activate one of the layers with a range of dates. Press compare in legend to be able to see the dropdown there._

### Feature relevant tickets

_[Link to the related task manager tickets](https://vizzuality.atlassian.net/browse/OEMC-135?atlOrigin=eyJpIjoiY2M5MGNmOGMwMzY4NDQyZThjMzY1OGFjYTczZjNhMDMiLCJwIjoiaiJ9)_

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] Update CHANGELOG
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist 

