### PR TITLE
info button removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Metadata info in monitors and geostories [OEMC-41](https://vizzuality.atlassian.net/browse/OEMC-41) [OEMC-32](https://vizzuality.atlassian.net/browse/OEMC-32) [OEMC-30](https://vizzuality.atlassian.net/browse/OEMC-30)
-
+- Removed info button at datasets level [OEMC-69](https://vizzuality.atlassian.net/browse/OEMC-69)
 ## v0.1.0-alpha.1
 
 ### Added

--- a/src/components/datasets/card/index.tsx
+++ b/src/components/datasets/card/index.tsx
@@ -1,6 +1,5 @@
 import { FC, useCallback, useEffect, useMemo } from 'react';
 
-import { FiInfo } from 'react-icons/fi';
 import { HiOutlineExternalLink } from 'react-icons/hi';
 import { LuLayers } from 'react-icons/lu';
 
@@ -9,7 +8,6 @@ import cn from '@/lib/classnames';
 import type { LayerParsed } from '@/types/layers';
 
 import TimeSeries from '@/components/timeseries';
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 
 import { useSyncCompareLayersSettings, useSyncLayersSettings } from '../../../hooks/sync-query';
 
@@ -25,7 +23,6 @@ const DatasetCard: FC<DatasetCardProps> = ({
   title,
   download_url,
   description,
-  author,
   gs_style: legendStyles,
   range,
   defaultActive = false,
@@ -90,18 +87,6 @@ const DatasetCard: FC<DatasetCardProps> = ({
           {title}
         </h2>
         <div className="mt-1.5 flex items-baseline space-x-2">
-          <Popover>
-            <PopoverTrigger data-testid="dataset-info-button">
-              <FiInfo className="h-6 w-6" title="Show info" />
-            </PopoverTrigger>
-            <PopoverContent align="center" sideOffset={5} data-testid="dataset-info-content">
-              <div className="flex flex-col">
-                <ul>
-                  <li>Data author: {author}</li>
-                </ul>
-              </div>
-            </PopoverContent>
-          </Popover>
           {!!download_url && (
             <a
               href={download_url}


### PR DESCRIPTION
## Info button removed

### Overview

_Info button at datasets level removed._


### Testing instructions

![Screenshot 2023-12-18 at 12 51 20](https://github.com/Open-Earth-Monitor/oemc/assets/33252015/edd650af-49fe-434e-91b6-c53ebe3ba35c)

### Feature relevant tickets

_[Link to the related task manager tickets](https://vizzuality.atlassian.net/browse/OEMC-69)_

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] Update CHANGELOG
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist 

