### PR TITLE
hub and map style amendments

### DIFF
--- a/src/components/datasets-grid/index.tsx
+++ b/src/components/datasets-grid/index.tsx
@@ -108,9 +108,9 @@ const LandingDatasets = () => {
                     onClick={handleThemes}
                     defaultChecked
                     checked={activeThemes.includes(theme)}
-                    className="border border-secondary-500 text-brand-500 outline-none ring-0"
+                    className="bg-secondary-500 text-brand-500 outline-none ring-0 hover:border-2 hover:border-secondary-500 hover:bg-secondary-900 data-[state=checked]:border-none"
                   >
-                    <CheckboxIndicator className="border-none bg-secondary-500 text-brand-500 outline-0 ring-0">
+                    <CheckboxIndicator className="border-none bg-secondary-500 text-brand-500 outline-0 ring-0 hover:bg-secondary-900">
                       <BiCheck className="h-4 w-4 fill-current" />
                     </CheckboxIndicator>
                   </Checkbox>

--- a/src/components/footer/index.tsx
+++ b/src/components/footer/index.tsx
@@ -4,6 +4,8 @@ import { FC } from 'react';
 
 import Image from 'next/image';
 
+import { motion } from 'framer-motion';
+
 import {
   Dialog,
   DialogContent,
@@ -34,7 +36,17 @@ export const Footer: FC = () => {
           <div className="flex flex-1 cursor-pointer items-center justify-center space-x-10 text-sm font-medium text-secondary-500">
             <Dialog>
               <DialogTrigger asChild data-testid="disclaimer">
-                <div>Disclaimer</div>
+                <motion.div initial="initial" whileHover="hover" className="w-fit">
+                  <span>Disclaimer</span>
+
+                  <motion.div
+                    className="h-0.5 w-0 bg-secondary-500"
+                    variants={{
+                      initial: { width: 0 },
+                      hover: { width: '100%' },
+                    }}
+                  />
+                </motion.div>
               </DialogTrigger>
               <DialogContent className="top-1/2 w-[665px] -translate-y-[50%] transform bg-secondary-500 text-brand-500">
                 <DialogHeader className="space-y-5">
@@ -74,7 +86,9 @@ export const Footer: FC = () => {
               </DialogContent>
             </Dialog>
 
-            <a
+            <motion.a
+              initial="initial"
+              whileHover="hover"
               target="_blank"
               rel="noopener noreferrer"
               href="https://earthmonitor.org/privacy-policy/"
@@ -83,9 +97,18 @@ export const Footer: FC = () => {
               aria-label="OEMC privacy policy"
               data-testid="privacy-policy-link"
             >
-              Privacy Policy
-            </a>
-            <a
+              <span>Privacy Policy</span>
+              <motion.div
+                className="h-0.5 w-0 bg-secondary-500"
+                variants={{
+                  initial: { width: 0 },
+                  hover: { width: '100%' },
+                }}
+              />
+            </motion.a>
+            <motion.a
+              initial="initial"
+              whileHover="hover"
               target="_blank"
               rel="noopener noreferrer"
               href="https://earthmonitor.org/contact-us/"
@@ -94,8 +117,15 @@ export const Footer: FC = () => {
               aria-label="OEMC contact page"
               data-testid="contact-link"
             >
-              Contact us
-            </a>
+              <span>Contact us</span>{' '}
+              <motion.div
+                className="h-0.5 w-0 bg-secondary-500"
+                variants={{
+                  initial: { width: 0 },
+                  hover: { width: '100%' },
+                }}
+              />
+            </motion.a>
           </div>
           <SocialMedia />
         </div>

--- a/src/components/geostories/card/index.tsx
+++ b/src/components/geostories/card/index.tsx
@@ -20,13 +20,13 @@ const GeostoryCard: FC<Partial<Geostory> & { color?: string; colorHead?: string 
   return (
     <div
       className="flex min-h-[468px] flex-col justify-between"
-      style={{ backgroundColor: color }}
+      style={{ backgroundColor: color, color: ready ? 'inherit' : '#000' }}
       data-testid={`card-${id}`}
     >
       <div>
         <div
           className="flex min-h-[235px] grow-0 flex-col justify-between space-y-4 px-8 py-6"
-          style={{ backgroundColor: colorHead }}
+          style={{ backgroundColor: colorHead, color: ready ? 'inherit' : '#000' }}
         >
           <div className="space-y-2">
             <div data-testid={`card-type-${id}`} className={TAG_STYLE}>
@@ -37,7 +37,7 @@ const GeostoryCard: FC<Partial<Geostory> & { color?: string; colorHead?: string 
             </h2>
           </div>
           {ready ? (
-            <div className="flex items-center space-x-4">
+            <div className="flex items-center space-x-8">
               <GeostoryDialog {...geostory} />
               <Link
                 href={`/map/geostories/${id}`}
@@ -54,7 +54,7 @@ const GeostoryCard: FC<Partial<Geostory> & { color?: string; colorHead?: string 
             <div>
               <div className="float-left flex items-center space-x-2 rounded-md bg-black/10 px-3 py-2 leading-none">
                 <LuRefreshCcw className="h-5 w-5" />
-                <span className="text-xs">Geostory under-development</span>
+                <span className="text-xs font-bold">Geostory under-development</span>
               </div>
             </div>
           )}

--- a/src/components/geostories/dialog/index.tsx
+++ b/src/components/geostories/dialog/index.tsx
@@ -31,7 +31,7 @@ const GeostoryDialog: React.FC<GeostoryDialogProps> = ({
 }) => (
   <Dialog>
     <DialogTrigger asChild>
-      <Button data-testid={`card-button-${id}`} className="max-w-fit p-4">
+      <Button data-testid={`card-button-${id}`} className="max-w-fit p-4 text-xs">
         Know more
       </Button>
     </DialogTrigger>

--- a/src/components/hero/index.tsx
+++ b/src/components/hero/index.tsx
@@ -16,7 +16,7 @@ const Hero = () => {
   return (
     <div className="relative bg-[url('/images/landing/hero.png')] bg-cover bg-right-bottom xl:pt-36">
       <div className="m-auto max-w-[1200px]">
-        <h1 className="whitespace-wrap max-w-[800px] pb-20 pt-36 font-satoshi text-8xl font-black">
+        <h1 className="whitespace-wrap max-w-[800px] pb-20 pt-32 font-satoshi text-8xl font-black md:pt-36">
           {' '}
           Discover and empower with monitoring solutions.
         </h1>

--- a/src/components/map/index.tsx
+++ b/src/components/map/index.tsx
@@ -135,7 +135,7 @@ const Map: FC<CustomMapProps> = ({ initialViewState = DEFAULT_VIEWPORT, isGeosto
         )}
 
         <Controls className="absolute bottom-3 left-[554px] z-50 flex flex-col">
-          <RControl.RZoom />
+          <RControl.RZoom zoomOutLabel="-" zoomInLabel="+" />
           <BookmarkControl />
           <ShareControl />
           {isCompareLayerActive && <SwipeControl />}

--- a/src/components/monitors/card/index.tsx
+++ b/src/components/monitors/card/index.tsx
@@ -19,7 +19,7 @@ const MonitorCard: FC<Partial<Monitor> & { color?: string }> = (monitor) => {
   return (
     <div
       className="flex h-[468px] flex-col justify-between px-8 py-6 text-brand-500"
-      style={{ backgroundColor: color }}
+      style={{ backgroundColor: color, color: ready && '#000' }}
       data-testid={`card-${id}`}
     >
       <div className="space-y-4">
@@ -35,7 +35,7 @@ const MonitorCard: FC<Partial<Monitor> & { color?: string }> = (monitor) => {
         {description && <p data-testid={`card-description-${id}`}>{description}</p>}
 
         {ready ? (
-          <div className="flex items-center space-x-4">
+          <div className="flex items-center space-x-8">
             <MonitorDialog {...monitor} />
             <Link
               href={`/map/${id}/datasets`}
@@ -52,7 +52,7 @@ const MonitorCard: FC<Partial<Monitor> & { color?: string }> = (monitor) => {
           <div>
             <div className="float-left flex items-center space-x-2 rounded-md bg-black/10 px-3 py-2 leading-none">
               <LuRefreshCcw className="h-5 w-5" />
-              <span className="text-xs">Monitor under-development</span>
+              <span className="text-xs font-bold">Monitor under-development</span>
             </div>
           </div>
         )}

--- a/src/components/monitors/dialog/index.tsx
+++ b/src/components/monitors/dialog/index.tsx
@@ -30,7 +30,7 @@ const MonitorDialog: React.FC<MonitorDialogProps> = ({
 }) => (
   <Dialog>
     <DialogTrigger asChild>
-      <Button variant="light" data-testid={`card-button-${id}`} className="max-w-fit p-4">
+      <Button variant="light" data-testid={`card-button-${id}`} className="max-w-fit p-4 text-xs">
         Know more
       </Button>
     </DialogTrigger>

--- a/src/components/pagination/index.tsx
+++ b/src/components/pagination/index.tsx
@@ -50,16 +50,19 @@ const Pagination: React.FC<PaginationProps> = ({
       </button>
       <ol className="flex space-x-8" data-testid="pages-list">
         {pagesToShow.map((d, index) => (
-          <li
-            key={d}
-            data-testid={`pagination-item-${index}`}
-            className={cn({
-              'm-auto flex h-10 w-10 items-center justify-center rounded-full text-secondary-500':
-                true,
-              'bg-secondary-500  text-brand-500': d === page,
-            })}
-          >
-            <button type="button" onClick={handleCurrentPage} value={d}>
+          <li key={d} data-testid={`pagination-item-${index}`}>
+            <button
+              type="button"
+              className={cn({
+                'm-auto flex h-10 w-10 items-center justify-center rounded-full text-secondary-500':
+                  true,
+                'hover:bg-secondary-900': d !== page,
+                'bg-secondary-500 text-brand-500': d === page,
+              })}
+              onClick={handleCurrentPage}
+              value={d}
+              disabled={d === page}
+            >
               {d}
             </button>
           </li>

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -13,7 +13,7 @@ const Checkbox = forwardRef<
   <CheckboxPrimitive.Root
     ref={ref}
     className={cn({
-      'h-4 w-4 shrink-0 bg-transparent shadow focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed data-[state=checked]:bg-primary data-[state=checked]:text-secondary-500':
+      'h-4 w-4 shrink-0 bg-transparent shadow focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed data-[state=checked]:bg-primary data-[state=checked]:text-secondary-500 data-[state=checked]:ring-0 data-[state=checked]:ring-offset-0':
         true,
       [className]: !!className,
     })}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -48,7 +48,7 @@ const DialogOverlay = forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      'fixed inset-0 z-40 bg-brand-500 opacity-40 backdrop-blur-3xl data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      'fixed inset-0 z-40 bg-brand-500 opacity-90 backdrop-blur-3xl data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
       className
     )}
     {...props}

--- a/src/hooks/datasets.ts
+++ b/src/hooks/datasets.ts
@@ -7,9 +7,14 @@ import type {
   MonitorsAndGeostoriesPaginatedParsed,
 } from '@/types/monitors-and-geostories';
 
-import { THEMES_COLORS } from '@/constants/themes';
+import { Theme, THEMES_COLORS } from '@/constants/themes';
 
 import API from 'services/api';
+
+const getColor = (ready: boolean, theme: Theme, themeType: 'base' | 'dark' | 'light') => {
+  if (!ready) return 'hsla(0, 0%, 79%, 1)';
+  return THEMES_COLORS[theme][themeType] || THEMES_COLORS.Unknown[themeType];
+};
 
 type UseParams = {
   type?: 'monitors' | 'geostories' | 'all';
@@ -75,9 +80,9 @@ export function useMonitorsAndGeostoriesPaginated(
       ...data,
       data: data['monitors and geostories'].map((d) => ({
         ...d,
-        color: THEMES_COLORS[d.theme].base || THEMES_COLORS.Unknown.base,
-        colorHead: THEMES_COLORS[d.theme].dark || THEMES_COLORS.Unknown.dark,
-        colorOpacity: THEMES_COLORS[d.theme].light || THEMES_COLORS.Unknown.light,
+        color: getColor(d.ready, d.theme, 'base'),
+        colorHead: getColor(d.ready, d.theme, 'dark'),
+        colorOpacity: getColor(d.ready, d.theme, 'light'),
       })),
     }),
   });

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -150,8 +150,10 @@
 .ol-zoom-in, .ol-zoom-out {
   color: hsl(60, 100%, 95%) !important;
   background-color: hsl(210, 54%, 9%) !important;
-  font-size: 24px !important;
   outline-offset: 0px !important;
+  height: 100% !important;
+  width: 100% !important;
+  overflow: hidden !important;
 }
 
 .ol-zoom-in:hover, .ol-zoom-out:hover {
@@ -160,16 +162,20 @@
 }
 
 .ol-zoom-out {
-  font-size: 22px !important;
-  padding-top: 4px !important;
-  padding-bottom: 8px !important;
+  font-size: 32px !important;
+  padding-bottom: 4px !important;
 }
+
+.ol-zoom-in {
+  font-size: 24px !important;
+}
+
 
 .ol-swipe::before {
   background-color: hsla(210, 9%, 22%, 1) !important;
 }
 
-.ol-swipe, .ol-control {
+.ol-swipe {
   background-color: transparent !important;
 }
 


### PR DESCRIPTION
## Styles amendments in Hub and map page

### Overview

## Hub page

- Smaller padding in Hero so the title is completely visible on small screens. 
- Know More and Go To buttons text size standardized. ([Check prototype](https://www.figma.com/file/G3qygCzHDtdVaHdzudoH0G/%E2%9C%85-Open-Earth-Monitor---Prototype-%5BShared%5D---September?type=design&node-id=0%3A1&mode=design&t=yWy0qvAoOjLYNPIB-1))
- Cards under development changed to grey with black text.
- Hover state for the pagination added
- Hover state (underline) for links in the footer (Disclaimer, Privacy Policy, Contact Us) added
-  “Monitor under-development” text changed to bold.

Map:

- Background darker when modal windows are activated like Disclaimer, Attributions. ([Check prototype](https://www.figma.com/file/G3qygCzHDtdVaHdzudoH0G/%E2%9C%85-Open-Earth-Monitor---Prototype-%5BShared%5D---September?type=design&node-id=0%3A1&mode=design&t=yWy0qvAoOjLYNPIB-1))

- Square  behind the drag/slider button that splits the Map in Compare mode removed.
- Zoom control styles fiex

### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

_Please explain how to test the PR: ID of a dataset, steps to reach the feature, etc._

### Feature relevant tickets

_[Link to the related task manager tickets](https://vizzuality.atlassian.net/browse/OEMC-164)_

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] Update CHANGELOG
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist 

