### PR TITLE
know more added to geo story

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Removed info button at datasets level [OEMC-69](https://vizzuality.atlassian.net/browse/OEMC-69)
+- Geostory info moved from sidebar to geostory dialog [OEMC-163](https://vizzuality.atlassian.net/browse/OEMC-163)
 
 ### Fixed
 - Wrong link in geostory card on the landing page

--- a/src/app/map/geostories/[geostory_id]/page.tsx
+++ b/src/app/map/geostories/[geostory_id]/page.tsx
@@ -6,7 +6,6 @@ import Link from 'next/link';
 
 import type { NextPage } from 'next';
 import { HiArrowLeft } from 'react-icons/hi';
-import { HiOutlineNewspaper, HiOutlineGlobeAlt } from 'react-icons/hi';
 
 import type { MonitorParsed } from '@/types/monitors';
 
@@ -81,44 +80,6 @@ const GeostoryPage: NextPage<{ params: { geostory_id: string } }> = ({
           </ul>
         )}
       </div>
-      {geostory && !isLoadingGeostory && (
-        <div className="divide-y divide-secondary-900">
-          <div className="p-6">
-            <h3 className="flex items-center space-x-2">
-              <HiOutlineGlobeAlt className="h-6 w-6" />
-              <span className="font-satoshi text-2xl font-bold">Use cases</span>
-            </h3>
-            {geostory.use_case_link.length > 0 && (
-              <ul className="space-y-2 py-2 font-bold">
-                {geostory.use_case_link.map(({ url, title }) => (
-                  <li key={title}>
-                    <a href={url} className="underline">
-                      {title}
-                    </a>
-                  </li>
-                ))}
-              </ul>
-            )}
-          </div>
-          <div className="p-6">
-            <h3 className="flex items-center space-x-2">
-              <HiOutlineNewspaper className="h-6 w-6" />
-              <span className="font-satoshi text-2xl font-bold">Publications</span>
-            </h3>
-            {geostory.publications.length > 0 && (
-              <ul className="space-y-2 py-2 font-bold">
-                {geostory.publications.map(({ url, title }) => (
-                  <li key={title}>
-                    <a href={url} className="underline">
-                      {title}
-                    </a>
-                  </li>
-                ))}
-              </ul>
-            )}
-          </div>
-        </div>
-      )}
     </div>
   );
 };

--- a/src/app/map/geostories/[geostory_id]/page.tsx
+++ b/src/app/map/geostories/[geostory_id]/page.tsx
@@ -15,7 +15,7 @@ import { useMonitors } from '@/hooks/monitors';
 import { useSyncLayersSettings, useSyncCompareLayersSettings } from '@/hooks/sync-query';
 
 import DatasetCard from '@/components/datasets/card';
-import GeostoryHead from '@/components/geostories/header';
+import GeostoryHeader from '@/components/geostories/header';
 import Loading from '@/components/loading';
 
 const findMonitorByGeoStoryId = (monitors: MonitorParsed[], geoStoryId: string) =>
@@ -61,7 +61,7 @@ const GeostoryPage: NextPage<{ params: { geostory_id: string } }> = ({
           </Link>
         )}
         {isLoadingGeostory && <Loading />}
-        {geostory && !isLoadingGeostory && <GeostoryHead {...geostory} color={color} />}
+        {geostory && !isLoadingGeostory && <GeostoryHeader {...geostory} color={color} />}
       </div>
       <div>
         {isLoading && <Loading />}

--- a/src/components/geostories/dialog/index.tsx
+++ b/src/components/geostories/dialog/index.tsx
@@ -89,7 +89,7 @@ const GeostoryDialog: React.FC<GeostoryDialogProps> = ({
                   <HiOutlineNewspaper className="h-6 w-6" />
                   <span className="text-2xl font-bold">Publications</span>
                 </h3>
-                {publications.length > 0 && (
+                {publications?.length > 0 && (
                   <ul className="space-y-2 py-2 pl-8 font-bold">
                     {publications.map(({ url, title }) => (
                       <li key={title}>
@@ -106,7 +106,7 @@ const GeostoryDialog: React.FC<GeostoryDialogProps> = ({
                   <HiOutlineGlobeAlt className="h-6 w-6" />
                   <span className="text-2xl font-bold">Use cases</span>
                 </h3>
-                {use_case_link.length > 0 && (
+                {use_case_link?.length > 0 && (
                   <ul className="space-y-2 py-2 pl-8 font-bold">
                     {use_case_link.map(({ url, title }) => (
                       <li key={title}>

--- a/src/components/geostories/header/index.tsx
+++ b/src/components/geostories/header/index.tsx
@@ -2,56 +2,22 @@ import { FC } from 'react';
 
 import type { Geostory } from '@/types/geostories';
 
+import { THEMES_COLORS } from '@/constants/themes';
+
+import GeostoryDialog from '@/components/geostories/dialog';
 import { TAG_STYLE } from '@/styles/constants';
 
-const GeostoryHeader: FC<Geostory & { color: string }> = ({
-  title,
-  description,
-  notebooks_url,
-  author,
-  metadata_url,
-  color,
-}) => {
-  return (
-    <>
-      <div className="space-y-6 p-6">
-        {/* TODO - get color from API when we get categories */}
-        <div className={TAG_STYLE} style={{ color }}>
-          geostory
-        </div>
-        <h1 className="font-satoshi text-4xl font-bold">{title}</h1>
-        <p className="text-xl font-light">{description}</p>
-      </div>
-      <div className="p-6">
-        <dl className="space-y-2 py-2">
-          <div>
-            <dt className="inline-block whitespace-nowrap font-bold">Author:</dt>
-            <dd>{author && <span className="inline-block break-all">{author}</span>}</dd>
-          </div>
-          <div>
-            <dt className="inline-block whitespace-nowrap font-bold">Computational notebook:</dt>
-            <dd>
-              {notebooks_url && (
-                <a href={notebooks_url} className="inline-block break-all underline">
-                  {notebooks_url}
-                </a>
-              )}
-            </dd>
-          </div>
-          <div>
-            <dt className="inline-block whitespace-nowrap font-bold">Metadata link:</dt>
-            <dd>
-              {metadata_url && (
-                <a href={metadata_url} className="inline-block break-all underline">
-                  {metadata_url}
-                </a>
-              )}
-            </dd>
-          </div>
-        </dl>
-      </div>
-    </>
-  );
-};
+const GeostoryHeader: FC<Geostory & { color: string }> = (data) => (
+  <div className="space-y-6 p-6">
+    <div className={TAG_STYLE} style={{ color: THEMES_COLORS[data.theme].base }}>
+      geostory
+    </div>
+    <h1 className="font-satoshi text-4xl font-bold">{data.title}</h1>
+    <p className="text-xl font-light">{data.description}</p>
+    <div className="flex items-center">
+      <GeostoryDialog {...data} />
+    </div>
+  </div>
+);
 
 export default GeostoryHeader;


### PR DESCRIPTION
## Info updated on geo stories page

### Overview

- “know more” dialog added to geo story header. 
- Information displayed in dialog has been removed from the geo story page ( publications and use cases left is sidebar according to design)
- Color in geo story updated according to geo story theme


### Designs

_[Link to the related design prototypes (if applicable)](https://www.figma.com/file/Xz2WD4UWH3R6OdmeqmAMbF/%E2%9C%85-Open-Earth-Monitor---Prototype-%5BInternal%5D---September?node-id=1507%3A4018&mode=dev)_

### Testing instructions

_Please explain how to test the PR: ID of a dataset, steps to reach the feature, etc._

### Feature relevant tickets

_[Link to the related task manager tickets](https://vizzuality.atlassian.net/browse/OEMC-163?atlOrigin=eyJpIjoiNTE4NjE3MmZmZGNkNDRkZThlZTVhMzVhNjAxZDM3NjkiLCJwIjoiaiJ9)_

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] Update CHANGELOG
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist 

