### PR TITLE
map key removed

### DIFF
--- a/src/components/map/index.tsx
+++ b/src/components/map/index.tsx
@@ -80,11 +80,11 @@ const Map: FC<CustomMapProps> = ({ initialViewState = DEFAULT_VIEWPORT, isGeosto
   return (
     <>
       <RMap
-        key={`${initialViewport.center.join('-')}-${initialViewport.zoom}`}
         width="100%"
         height="100%"
         className="relative"
         initial={initialViewport}
+        view={[initialViewport, null]}
         onMoveEnd={handleMapMove}
         noDefaultControls
       >


### PR DESCRIPTION
## Avoid unnecessary rendering on the map

### Overview

- Map key removed to prevent map re-render.
- Initial state added to map view so zoom and center are always updated in the view without rendering.


## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] Update CHANGELOG
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist 

