### PR TITLE
in geostories, center map given bounds from api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added a default env variable for the API_URL
-- BaseMap boundaries [OEMC-185](https://vizzuality.atlassian.net/browse/OEMC-185?atlOrigin=eyJpIjoiODg1NTVjZTg1YmI2NDg4Mzg3NWFlYjg0NDgxNjRmNDAiLCJwIjoiaiJ9)
-- BaseMap labels [OEMC-185](https://vizzuality.atlassian.net/browse/OEMC-185?atlOrigin=eyJpIjoiODg1NTVjZTg1YmI2NDg4Mzg3NWFlYjg0NDgxNjRmNDAiLCJwIjoiaiJ9)
+- BaseMap boundaries [OEMC-185](https://vizzuality.atlassian.net/browse/OEMC-185)
+- BaseMap labels [OEMC-185](https://vizzuality.atlassian.net/browse/OEMC-185)
+- On the geostory page, center the map given bounds from the API [OEMC-190](https://vizzuality.atlassian.net/browse/OEMC-190)
 
 ## v1.0.0-alpha.3
 
@@ -22,9 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Removed info button at datasets level [OEMC-69](https://vizzuality.atlassian.net/browse/OEMC-69)
 - Geostory info moved from sidebar to geostory dialog [OEMC-163](https://vizzuality.atlassian.net/browse/OEMC-163)
-- Ability to filter by multiple categories (themes) in Hub page [OEMC-165](https://vizzuality.atlassian.net/browse/OEMC-165?atlOrigin=eyJpIjoiNWE1ZmY3MWU3ZGJlNGU0ZmFjZGU3NGUyM2E3ZTBkMjMiLCJwIjoiaiJ9)
-- Legend should be visible all time, legend redesign [OEMC-186](https://vizzuality.atlassian.net/browse/OEMC-186?atlOrigin=eyJpIjoiZTBiYzA3MTA5MWE2NGVlM2EzZjBiOTIzZjYwZjlhMDIiLCJwIjoiaiJ9)
-- Autoplay in monitors removed [OEMC-201](https://vizzuality.atlassian.net/browse/OEMC-201?atlOrigin=eyJpIjoiYjU1M2IwZmY5YWQxNDI4MmIzNjY4MTgwYTIxOThhZjQiLCJwIjoiaiJ9)
+- Ability to filter by multiple categories (themes) in Hub page [OEMC-165](https://vizzuality.atlassian.net/browse/OEMC-165)
+- Legend should be visible all time, legend redesign [OEMC-186](https://vizzuality.atlassian.net/browse/OEMC-186)
+- Autoplay in monitors removed [OEMC-201](https://vizzuality.atlassian.net/browse/OEMC-201)
 
 ### Fixed
 - Wrong link in geostory card on the landing page
@@ -45,14 +46,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Filtering monitors with layers only in map
 - Temporally add monitors with no categories
 - Unifying link styles in landing [OEMC-144](https://vizzuality.atlassian.net/browse/OEMC-144)
-- Display of monitors and geostories in landing page [OEMC-25](https://vizzuality.atlassian.net/browse/OEMC-25?atlOrigin=eyJpIjoiNDZiOTM0YjkzN2NlNDJhNmE2OWJiODYxZTlmYzcwNjkiLCJwIjoiaiJ9)
-- Search monitors and geostories by title [OEMC-94](https://vizzuality.atlassian.net/browse/OEMC-94?atlOrigin=eyJpIjoiMGVlYmJhNmM5ODU4NDRiNWEzNTIyNWRjODdjNDg4MWUiLCJwIjoiaiJ9)
-- 404 - error management [OEMC-81](https://vizzuality.atlassian.net/browse/OEMC-81?atlOrigin=eyJpIjoiNWZkNTYwMjVkZGVjNDAwZGE2YWI3ZDgwMzgzOTRjMjEiLCJwIjoiaiJ9)
-- Sorting items in landing page [OEMC-24](https://vizzuality.atlassian.net/browse/OEMC-24?atlOrigin=eyJpIjoiZTlmNGE1Njk3MTRlNDNjMmExY2I3YmE1ZjUzMTBkYjIiLCJwIjoiaiJ9)
-- Alpha version tag added to site [OEMC-127](https://vizzuality.atlassian.net/browse/OEMC-127?atlOrigin=eyJpIjoiYzBiNGI0NDcwOGUzNGYzMzgzM2I1NWVhMWE0NjFkZjciLCJwIjoiaiJ9)
-- Functionality for returning from a geostory to its associated monitor [OEMC-121](https://vizzuality.atlassian.net/browse/OEMC-121?atlOrigin=eyJpIjoiNWY1OTkwZDNlMWNiNDA4M2JiOWM0NDNiODlkMDBlNmUiLCJwIjoiaiJ9)
-- Links to social media (twitter, github and linkedin), link to "contact us" and "privacy policy" [OEMC-108](https://vizzuality.atlassian.net/browse/OEMC-108?atlOrigin=eyJpIjoiMTFhMjI4MmE1NjYzNDNiNmJlNWFlOGJjYWI4MjdhYjQiLCJwIjoiaiJ9)
-- Pagination in monitors and geostories hub [OEMC-20](https://vizzuality.atlassian.net/browse/OEMC-133?atlOrigin=eyJpIjoiMGFlYjg0NWM4Mzk3NDBjN2JhNjkzMzRhZmI4MTIyZDgiLCJwIjoiaiJ9)
+- Display of monitors and geostories in landing page [OEMC-25](https://vizzuality.atlassian.net/browse/OEMC-25)
+- Search monitors and geostories by title [OEMC-94](https://vizzuality.atlassian.net/browse/OEMC-94)
+- 404 - error management [OEMC-81](https://vizzuality.atlassian.net/browse/OEMC-81)
+- Sorting items in landing page [OEMC-24](https://vizzuality.atlassian.net/browse/OEMC-24)
+- Alpha version tag added to site [OEMC-127](https://vizzuality.atlassian.net/browse/OEMC-127)
+- Functionality for returning from a geostory to its associated monitor [OEMC-121](https://vizzuality.atlassian.net/browse/OEMC-121)
+- Links to social media (twitter, github and linkedin), link to "contact us" and "privacy policy" [OEMC-108](https://vizzuality.atlassian.net/browse/OEMC-108)
+- Pagination in monitors and geostories hub [OEMC-20](https://vizzuality.atlassian.net/browse/OEMC-133)
 - Show monitors under development [OEMC-149](https://vizzuality.atlassian.net/browse/OEMC-149)
 
 ### Changed
@@ -62,23 +63,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Satoshi Font, main navigation, and test for navigation functionality [OEMC-18](https://vizzuality.atlassian.net/browse/OEMC-18)
-- Map set up and layers display [OEMC-23](https://vizzuality.atlassian.net/jira/software/c/projects/OEMC/boards/95?selectedIssue=OEMC-23)
-- Map controls to move around the map (zoom in, out, fit bounds)[OEMC-44](https://vizzuality.atlassian.net/browse/OEMC-44?atlOrigin=eyJpIjoiMGYzNzk5OWQwNmExNDRkNjllOWE5NWMxNjc4MmIwMmQiLCJwIjoiaiJ9)
-- Toggle layers displayed on the map [OEMC-58](https://vizzuality.atlassian.net/browse/OEMC-58?atlOrigin=eyJpIjoiMTgyZDgyNzgzNzBhNGMxODljZThjYTk0YTQ3N2VkYzciLCJwIjoiaiJ9)
-- Datasets display on the map [OECM-62](https://vizzuality.atlassian.net/browse/OEMC-62?atlOrigin=eyJpIjoiZThhZDBmZTQyYTJiNDM1ZmFmZWI4MzZhNGNjYjkzMWMiLCJwIjoiaiJ9)
-- Dataset info displayed on the sidebar [OEMC-21](https://vizzuality.atlassian.net/browse/OEMC-21?atlOrigin=eyJpIjoiZmM3NzkwNjlhMjA0NDUwOWExNDhiOGM0ODMwYTRkZGEiLCJwIjoiaiJ9)
-- Implement monitors directory [OEMC-65](https://vizzuality.atlassian.net/browse/OEMC-65?atlOrigin=eyJpIjoiZGZmYjJiNTg1NmY3NDhiM2I5NTNmMWZmMTIwZjA2NDMiLCJwIjoiaiJ9)
-- Legend settings (change opacity in layer, layer toggle visibility, remove layer) [OEMC-59](https://vizzuality.atlassian.net/browse/OEMC-59?atlOrigin=eyJpIjoiNDI0NzBkYmExODFmNGVjODllZDk3NTAyNjY4M2YwYzAiLCJwIjoiaiJ9)
-- Monitor geostories and datasets for selected geostory displayed on sidebar [OEMC-60](https://vizzuality.atlassian.net/browse/OEMC-60?atlOrigin=eyJpIjoiZjc4YjlhMTUzNTZkNGVmMWFhN2Y0OWI3ZDUyNWM2NDUiLCJwIjoiaiJ9)
-- Save bookmarks in map section [OEMC-72](https://vizzuality.atlassian.net/browse/OEMC-72?atlOrigin=eyJpIjoiYzg4MTQ2ZmJjZDQzNDBhMmI5NDg3M2YyZjM0Mzc4ZmUiLCJwIjoiaiJ9)
-- Stadiamaps basemap [OEMC-78](https://vizzuality.atlassian.net/browse/OEMC-78?atlOrigin=eyJpIjoiYzUzZmZjMDllNWI2NGY5Y2E1NmUwMmFjYmNhYmU2NjMiLCJwIjoiaiJ9)
-- Map view added to URL [OEMC-75](https://vizzuality.atlassian.net/browse/OEMC-75?atlOrigin=eyJpIjoiM2IyNDYxOTJkYzQ0NGY4NTgzOTgyODdkOThiYTJhMjAiLCJwIjoiaiJ9)
+- Map set up and layers display [OEMC-23](https://vizzuality.atlassian.net/browse/OEMC-23)
+- Map controls to move around the map (zoom in, out, fit bounds)[OEMC-44](https://vizzuality.atlassian.net/browse/OEMC-44)
+- Toggle layers displayed on the map [OEMC-58](https://vizzuality.atlassian.net/browse/OEMC-58)
+- Datasets display on the map [OECM-62](https://vizzuality.atlassian.net/browse/OEMC-62)
+- Dataset info displayed on the sidebar [OEMC-21](https://vizzuality.atlassian.net/browse/OEMC-21)
+- Implement monitors directory [OEMC-65](https://vizzuality.atlassian.net/browse/OEMC-65)
+- Legend settings (change opacity in layer, layer toggle visibility, remove layer) [OEMC-59](https://vizzuality.atlassian.net/browse/OEMC-59)
+- Monitor geostories and datasets for selected geostory displayed on sidebar [OEMC-60](https://vizzuality.atlassian.net/browse/OEMC-60)
+- Save bookmarks in map section [OEMC-72](https://vizzuality.atlassian.net/browse/OEMC-72)
+- Stadiamaps basemap [OEMC-78](https://vizzuality.atlassian.net/browse/OEMC-78)
+- Map view added to URL [OEMC-75](https://vizzuality.atlassian.net/browse/OEMC-75)
 
 
 ### Changed
-- Migration from react-map-gl to [openlayers](https://openlayers.org/) [OEMC-85](https://vizzuality.atlassian.net/browse/OEMC-85?atlOrigin=eyJpIjoiNGU0ZTdlMDY0ZTk0NGQzYTljNjIyMGMwMjNmZDZjOTgiLCJwIjoiaiJ9)
+- Migration from react-map-gl to [openlayers](https://openlayers.org/) [OEMC-85](https://vizzuality.atlassian.net/browse/OEMC-85)
 
 
 ### Fixed
-- Layer animation should keep visibility [OEMC-90](https://vizzuality.atlassian.net/browse/OEMC-90?atlOrigin=eyJpIjoiNTM0OWVlYmJmOWE4NDBiM2FjYjY4NGZlZjNiNzM4NjciLCJwIjoiaiJ9)
-- Visibility toggle should keep previous opacity value in the layer [OEMC-89](https://vizzuality.atlassian.net/browse/OEMC-89?atlOrigin=eyJpIjoiZDA0ZDIxYzdmNDU0NGExN2EwNzk2MDVkZGQ3NDlhOTciLCJwIjoiaiJ9)
+- Layer animation should keep visibility [OEMC-90](https://vizzuality.atlassian.net/browse/OEMC-90)
+- Visibility toggle should keep previous opacity value in the layer [OEMC-89](https://vizzuality.atlassian.net/browse/OEMC-89)

--- a/src/components/geostories/header/index.tsx
+++ b/src/components/geostories/header/index.tsx
@@ -1,13 +1,13 @@
 import { FC } from 'react';
 
-import type { Geostory } from '@/types/geostories';
+import type { GeostoryParsed } from '@/types/geostories';
 
 import { THEMES_COLORS } from '@/constants/themes';
 
 import GeostoryDialog from '@/components/geostories/dialog';
 import { TAG_STYLE } from '@/styles/constants';
 
-const GeostoryHeader: FC<Geostory & { color: string }> = (data) => (
+const GeostoryHeader: FC<GeostoryParsed> = (data) => (
   <div className="space-y-6 p-6">
     <div className={TAG_STYLE} style={{ color: THEMES_COLORS[data.theme].base }}>
       geostory

--- a/src/components/map/index.tsx
+++ b/src/components/map/index.tsx
@@ -1,11 +1,14 @@
 'use client';
 
-import React, { useMemo, FC, useCallback } from 'react';
+import React, { useMemo, FC, useCallback, useEffect } from 'react';
+
+import { useParams } from 'next/navigation';
 
 import { MapBrowserEvent } from 'ol';
 import { RLayerTileWMS, RMap, RLayerTile, RControl } from 'rlayers';
 import { RView } from 'rlayers/RMap';
 
+import { useGeostory } from '@/hooks/geostories';
 import { useLayerParsedSource } from '@/hooks/layers';
 import {
   useSyncLayersSettings,
@@ -28,6 +31,11 @@ const Map: FC<CustomMapProps> = ({ initialViewState = DEFAULT_VIEWPORT, isGeosto
   const [layers] = useSyncLayersSettings();
   const [center, setCenter] = useSyncCenterSettings();
   const [zoom, setZoom] = useSyncZoomSettings();
+  const { geostory_id } = useParams();
+  const { data: geostory, isLoading: isLoadingGeostory } = useGeostory(
+    { geostory_id: geostory_id as string },
+    { enabled: isGeostory }
+  );
 
   // Layer from the URL
   const layerId = layers?.[0]?.id;
@@ -77,14 +85,24 @@ const Map: FC<CustomMapProps> = ({ initialViewState = DEFAULT_VIEWPORT, isGeosto
     [setCenter, setZoom]
   );
 
+  useEffect(() => {
+    if (geostory && !isLoadingGeostory) {
+      document.title = geostory.title;
+    }
+  }, [geostory, isLoadingGeostory]);
+
   return (
     <>
       <RMap
+        projection="EPSG:3857"
         width="100%"
         height="100%"
         className="relative"
         initial={initialViewport}
         view={[initialViewport, null] as [RView, (view: RView) => void]}
+        // TO-DO: Fix the type of extent, remove once the API is fixed
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unnecessary-type-assertion
+        extent={(geostory?.geostory_bbox as unknown as string)?.split(',').map(Number) as number[]}
         onMoveEnd={handleMapMove}
         noDefaultControls
       >

--- a/src/components/map/index.tsx
+++ b/src/components/map/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useMemo, FC, useCallback, useEffect } from 'react';
+import React, { useMemo, FC, useCallback, useEffect, useRef } from 'react';
 
 import { useParams } from 'next/navigation';
 
@@ -28,6 +28,7 @@ import Legend from './legend';
 import type { CustomMapProps } from './types';
 
 const Map: FC<CustomMapProps> = ({ initialViewState = DEFAULT_VIEWPORT, isGeostory = false }) => {
+  const mapRef = useRef(null);
   const [layers] = useSyncLayersSettings();
   const [center, setCenter] = useSyncCenterSettings();
   const [zoom, setZoom] = useSyncZoomSettings();
@@ -87,22 +88,24 @@ const Map: FC<CustomMapProps> = ({ initialViewState = DEFAULT_VIEWPORT, isGeosto
 
   useEffect(() => {
     if (geostory && !isLoadingGeostory) {
-      document.title = geostory.title;
+      // TO-DO: Fix the type of extent, remove once the API is fixed
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+      mapRef?.current?.ol
+        .getView()
+        .fit((geostory?.geostory_bbox as unknown as string).split(',').map(Number));
     }
   }, [geostory, isLoadingGeostory]);
 
   return (
     <>
       <RMap
+        ref={mapRef}
         projection="EPSG:3857"
         width="100%"
         height="100%"
         className="relative"
         initial={initialViewport}
         view={[initialViewport, null] as [RView, (view: RView) => void]}
-        // TO-DO: Fix the type of extent, remove once the API is fixed
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unnecessary-type-assertion
-        extent={(geostory?.geostory_bbox as unknown as string)?.split(',').map(Number) as number[]}
         onMoveEnd={handleMapMove}
         noDefaultControls
       >

--- a/src/components/map/index.tsx
+++ b/src/components/map/index.tsx
@@ -87,7 +87,7 @@ const Map: FC<CustomMapProps> = ({ initialViewState = DEFAULT_VIEWPORT, isGeosto
   );
 
   useEffect(() => {
-    if (geostory && !isLoadingGeostory) {
+    if (geostory && !isLoadingGeostory && geostory?.geostory_bbox) {
       // TO-DO: Fix the type of extent, remove once the API is fixed
       // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
       mapRef?.current?.ol

--- a/src/hooks/geostories.ts
+++ b/src/hooks/geostories.ts
@@ -1,7 +1,7 @@
 import { useQuery, UseQueryOptions } from '@tanstack/react-query';
 import { AxiosResponse } from 'axios';
 
-import type { Geostory } from '@/types/geostories';
+import type { Geostory, GeostoryParsed } from '@/types/geostories';
 import type { Layer, LayerParsed } from '@/types/layers';
 
 import API from 'services/api';
@@ -28,7 +28,6 @@ export function useGeostory(params: UseParams, queryOptions?: UseQueryOptions<Ge
     }).then((response: AxiosResponse<Geostory[]>) => response.data[0]);
   return useQuery(['geostories', params], fetchGeostory, {
     ...DEFAULT_QUERY_OPTIONS,
-    select: (data) => data,
     ...queryOptions,
   });
 }
@@ -68,7 +67,6 @@ export function useGeostories(queryOptions?: UseQueryOptions<Geostory[], Error>)
     }).then((response: AxiosResponse<Geostory[]>) => response.data);
   return useQuery(['geostories'], fetchGeostories, {
     ...DEFAULT_QUERY_OPTIONS,
-    select: (data) => data,
     ...queryOptions,
   });
 }

--- a/src/types/geostories.d.ts
+++ b/src/types/geostories.d.ts
@@ -16,6 +16,7 @@ export type Geostory = {
   notebooks_url: string;
   publications: { title: string; url: string }[];
   use_case_link: { title: string; url: string }[];
+  geostory_bbox: number[] | null;
 };
 
 export type GeostoryParsed = Geostory & {


### PR DESCRIPTION
Center map on the bounds given by the API in a new field called `geostory_bbox`

When it exists, the map should be centered in that bounds. If not, set the map center and zoom in on the default one.