### PR TITLE
legend dropdowns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Using monitors attribute instead of layers to show monitor details [OEMC-225](https://vizzuality.atlassian.net/browse/OEMC-225)
+- Dropdown in legend styles and inteeractivity [OEMC-231](https://vizzuality.atlassian.net/browse/OEMC-231)
 
 ### Fixed
 - Fixed default layer was not showed in the map navigating monitors [OEMC-216](https://vizzuality.atlassian.net/browse/OEMC-216)

--- a/public/svgs/active-layer-position.svg
+++ b/public/svgs/active-layer-position.svg
@@ -1,0 +1,9 @@
+
+<svg width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect y="3.82355" width="7" height="12" rx="1.23529" fill="#FFFFE6"/>
+<mask id="path-2-inside-1_1251_2704" fill="white">
+<rect x="14" y="4" width="7" height="12" rx="1.23529"/>
+</mask>
+<rect x="14" y="4" width="7" height="12" rx="1.23529" stroke="#FFFFE6" stroke-width="2.6" mask="url(#path-2-inside-1_1251_2704)"/>
+<path d="M10.5 1.35297L10.5 18.6471" stroke="#FFFFE6" stroke-width="1.3" stroke-linecap="round"/>
+</svg>

--- a/src/components/map/legend/constants.ts
+++ b/src/components/map/legend/constants.ts
@@ -1,4 +1,6 @@
-export const DROPDOWN_TRIGGER_STYLES = 'w-full border-none px-3.5 py-2.5';
+export const DROPDOWN_TRIGGER_STYLES = 'w-full border-none pl-0 pr-2 py-2.5';
+export const DROPDOWN_TRIGGER_CONTENT_STYLES =
+  'flex w-full items-center space-x-1 whitespace-nowrap';
 export const DROPDOWN_CONTENT_STYLES = 'dropdown-menu-content z-[60] w-full bg-brand-500 px-0';
 export const DROPDOWN_ITEM_STYLES =
   'm-auto flex w-full flex-1 justify-center whitespace-nowrap py-0 px-2 text-center text-secondary-500 ';

--- a/src/components/map/legend/index.tsx
+++ b/src/components/map/legend/index.tsx
@@ -1,6 +1,8 @@
 import { useState, useEffect, useCallback, createRef, useLayoutEffect } from 'react';
 
-import { HiCalendarDays, HiArrowLeftOnRectangle } from 'react-icons/hi2';
+import Image from 'next/image';
+
+import { HiCalendarDays } from 'react-icons/hi2';
 import { LuGitCompare } from 'react-icons/lu';
 
 import { useLayerParsedSource, useLayer } from '@/hooks/layers';
@@ -19,6 +21,7 @@ import { Tabs, TabsContent, TabsTrigger, TabsList } from '@/components/ui/tabs';
 
 import {
   DROPDOWN_TRIGGER_STYLES,
+  DROPDOWN_TRIGGER_CONTENT_STYLES,
   DROPDOWN_CONTENT_STYLES,
   DROPDOWN_ITEM_STYLES,
 } from './constants';
@@ -36,8 +39,6 @@ const findLabel = (value: string, range: { label: string; value: string | number
 export const Legend: React.FC<{ isGeostory?: boolean }> = ({ isGeostory = false }) => {
   const [layers, setLayers] = useSyncLayersSettings();
   const [compareLayers, setCompareLayers] = useSyncCompareLayersSettings();
-  const [dropdownVisibility, setDropdownVisibility] = useState(false);
-  const [compareDropdownVisibility, setCompareDropdownVisibility] = useState(false);
 
   const handleTabChange = (value: ActiveTab) => {
     if (value === 'comparison') {
@@ -74,7 +75,6 @@ export const Legend: React.FC<{ isGeostory?: boolean }> = ({ isGeostory = false 
     (e: React.MouseEvent<HTMLButtonElement>) => {
       e.preventDefault();
       void setLayers([{ id: layerId, opacity, date: e.currentTarget.value }]);
-      setDropdownVisibility(false);
     },
     [layerId, opacity, setLayers]
   );
@@ -121,7 +121,6 @@ export const Legend: React.FC<{ isGeostory?: boolean }> = ({ isGeostory = false 
     (e: React.MouseEvent<HTMLButtonElement>) => {
       e.preventDefault();
       void setCompareLayers([{ id: layerId, opacity, date: e.currentTarget.value }]);
-      setCompareDropdownVisibility(false);
     },
     [layerId, opacity, setCompareLayers]
   );
@@ -237,7 +236,7 @@ export const Legend: React.FC<{ isGeostory?: boolean }> = ({ isGeostory = false 
                   <TabsTrigger value="comparison" disabled={!range || range.length < 1}>
                     <div className="flex items-center space-x-2">
                       <LuGitCompare className="h-[19px] w-[19px]" />
-                      <span>Comparison</span>
+                      <span>Compare</span>
                     </div>
                   </TabsTrigger>
                 </TabsList>
@@ -254,17 +253,21 @@ export const Legend: React.FC<{ isGeostory?: boolean }> = ({ isGeostory = false 
                 </TabsContent>
                 <TabsContent value="comparison">
                   <div className="flex w-full flex-col items-start">
-                    <div className=" divide-y divide-dashed">
-                      <DropdownMenu open={dropdownVisibility}>
-                        <DropdownMenuTrigger className={DROPDOWN_TRIGGER_STYLES} asChild>
-                          <button
-                            type="button"
-                            onClick={() => setDropdownVisibility(!dropdownVisibility)}
-                            className="flex w-full space-x-2 whitespace-nowrap"
-                          >
-                            <HiArrowLeftOnRectangle className="h-full w-4" />
-                            <span>Selected year: {baseDateLabel}</span>
-                          </button>
+                    <div className="w-full divide-x-0 divide-y divide-dashed">
+                      <DropdownMenu modal={false}>
+                        <DropdownMenuTrigger className={DROPDOWN_TRIGGER_STYLES}>
+                          <div className={DROPDOWN_TRIGGER_CONTENT_STYLES}>
+                            <Image
+                              src={`/svgs/active-layer-position.svg`}
+                              width={21}
+                              height={17}
+                              alt="left layer active"
+                            />
+                            <div>
+                              Selected year:{' '}
+                              <span className="font-bold tracking-tight">{baseDateLabel}</span>
+                            </div>
+                          </div>
                         </DropdownMenuTrigger>
                         <DropdownMenuContent
                           align="start"
@@ -291,19 +294,22 @@ export const Legend: React.FC<{ isGeostory?: boolean }> = ({ isGeostory = false 
                       {isGeostory ? (
                         <div className={DROPDOWN_TRIGGER_STYLES}>{compareLayerData?.title}</div>
                       ) : (
-                        <DropdownMenu open={compareDropdownVisibility}>
-                          <DropdownMenuTrigger className={DROPDOWN_TRIGGER_STYLES} asChild>
-                            <button
-                              type="button"
-                              onClick={() =>
-                                setCompareDropdownVisibility(!compareDropdownVisibility)
-                              }
-                              className="flex w-full space-x-2 whitespace-nowrap"
-                            >
-                              <HiArrowLeftOnRectangle className="h-full w-4 rotate-180" />
+                        <DropdownMenu modal={false}>
+                          <DropdownMenuTrigger className={DROPDOWN_TRIGGER_STYLES}>
+                            <div className={DROPDOWN_TRIGGER_CONTENT_STYLES}>
+                              <Image
+                                src={`/svgs/active-layer-position.svg`}
+                                width={20}
+                                height={20}
+                                alt="right layer active"
+                                className="rotate-180 transform"
+                              />
 
-                              <span>Selected year: {CompareDateLabel}</span>
-                            </button>
+                              <div>
+                                Selected year:{' '}
+                                <span className="font-bold tracking-tight">{CompareDateLabel}</span>
+                              </div>
+                            </div>
                           </DropdownMenuTrigger>
                           <DropdownMenuContent
                             align="start"


### PR DESCRIPTION
## Legend dropdown styles

### Overview

- The dropdowns should be the same width as the “Timeline/Comparison” switcher.
- Remove the outline around the dropdowns and only keep the divider (dashed grey line) between the two dropdowns
- Arrows in the dropdowns should be clickable both to open and close the dropdown.
- The icons for each dropdown need to be updated according to the new ones provided by design.

### Designs

_[Link to the related design prototypes (if applicable)](https://www.figma.com/file/G3qygCzHDtdVaHdzudoH0G/%E2%9C%85-Open-Earth-Monitor---Prototype-%5BShared%5D---September?node-id=1245%3A4515&mode=dev)_

### Testing instructions

_Activa compare option from the legend in map page_

### Feature relevant tickets

_[Link to the related task manager tickets](https://vizzuality.atlassian.net/browse/OEMC-231)_

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] Update CHANGELOG
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist 

