### PR TITLE
avoid showing main layer on the right when comparison is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dropdown in legend styles and inteeractivity [OEMC-231](https://vizzuality.atlassian.net/browse/OEMC-231)
 
 ### Fixed
+- In comparison left layer is also in the right side [OEMC-252](https://vizzuality.atlassian.net/browse/OEMC-252)
 - Warnings related to image sizes
 - Warnings related to ref and dropdowns
 - Tooltip was not updating value when date changes [OEMC-238](https://vizzuality.atlassian.net/browse/OEMC-238)

--- a/src/components/map/controls/swipe/index.tsx
+++ b/src/components/map/controls/swipe/index.tsx
@@ -24,6 +24,7 @@ const SwipeControl: React.FC<{
   useEffect(() => {
     if (layerLeft && layerRight) {
       swipeControl.setProperties({ position });
+      swipeControl.addLayer([layerLeft?.current?.ol], false);
       swipeControl.addLayer([layerRight?.current?.ol], true);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
This issue was because when the comparison was enabled we didn’t add the main layer to the left side programmatically as the documentation requires: “Layers that are not added are displayed on both sides“