### PR TITLE
monitors and geostories endpoint renamed

### DIFF
--- a/src/hooks/datasets.ts
+++ b/src/hooks/datasets.ts
@@ -92,7 +92,7 @@ export function useMonitorsAndGeostoriesPaginated(
     ...queryOptions,
     select: (data): MonitorsAndGeostoriesPaginatedParsed => ({
       ...data,
-      data: data['monitors and geostories'].map((d) => ({
+      data: data['results'].map((d) => ({
         ...d,
         color: getColor(d.ready, d.theme, 'base'),
         colorHead: getColor(d.ready, d.theme, 'dark'),

--- a/src/types/monitors-and-geostories.d.ts
+++ b/src/types/monitors-and-geostories.d.ts
@@ -6,7 +6,7 @@ export type MonitorsAndGeostories = (Monitor | Geostory)[];
 export type MonitorsAndGeostoriesParsed = (MonitorParsed | GeostoryParsed)[];
 
 export type MonitorsAndGeostoriesPaginated = {
-  'monitors and geostories': (Monitor | Geostory)[];
+  response: (Monitor | Geostory)[];
   next_page: string | null;
   previous_page: string | null;
   total_items: number;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -16,7 +16,7 @@ module.exports = {
       },
     },
     extend: {
-      fontFamily: {
+      font: {
         inter: ['var(--font-inter)'],
         satoshi: ['var(--font-satoshi)'],
       },


### PR DESCRIPTION
This pull request includes a change to the `useMonitorsAndGeostoriesPaginated` function in the `src/hooks/datasets.ts` file. The change updates the key used to access data in the `select` function.

* [`src/hooks/datasets.ts`](diffhunk://#diff-e36e989ebff68ceaa1f490dc4056e0442c92c2190ddb756771c0736ccd60538cL95-R95): Modified the key from `'monitors and geostories'` to `'results'` in the `useMonitorsAndGeostoriesPaginated` function.## Substitute this line for a meaningful title for your changes
