### PR TITLE
Feature/histogram chart

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,7 +28,7 @@ jobs:
         run: yarn playwright test
         env:
           NEXT_PUBLIC_API_URL: ${{ vars.NEXT_PUBLIC_API_URL }}
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: playwright-report

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Check installed Playwright browsers
         run: yarn playwright install --dry-run
       - name: Run Playwright tests
-        run: yarn playwright test --browser=chromium --headless=false
+        run: yarn playwright test --browser=chromium --headed
         env:
           NEXT_PUBLIC_API_URL: ${{ vars.NEXT_PUBLIC_API_URL }}
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           node-version-file: '.nvmrc'
       - name: Install project dependencies
-        run: yarn install --immutable
+        run: yarn install
       - name: Playwright install
         run: yarn playwright install --with-deps chrome
       - name: Check installed Playwright browsers

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -24,8 +24,10 @@ jobs:
         run: yarn install --immutable
       - name: Playwright install
         run: yarn playwright install --with-deps chrome
+      - name: Check installed Playwright browsers
+        run: yarn playwright install --dry-run
       - name: Run Playwright tests
-        run: yarn playwright test
+        run: yarn playwright test --browser=chromium --headless=false
         env:
           NEXT_PUBLIC_API_URL: ${{ vars.NEXT_PUBLIC_API_URL }}
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Check installed Playwright browsers
         run: yarn playwright install --dry-run
       - name: Run Playwright tests
-        run: yarn playwright test --browser=chromium --headed
+        run: yarn playwright test --headed
         env:
           NEXT_PUBLIC_API_URL: ${{ vars.NEXT_PUBLIC_API_URL }}
       - uses: actions/upload-artifact@v4

--- a/e2e/datasets-hub.spec.ts
+++ b/e2e/datasets-hub.spec.ts
@@ -15,8 +15,7 @@ test('geostories and monitors display', async ({ page }) => {
 
   const datasetsData = (await datasetsResponse.json()) as MonitorsAndGeostoriesPaginated;
 
-  // NEW RESPONSE
-  const pageLength = datasetsData['monitors and geostories'].results.length;
+  const pageLength = datasetsData['monitors and geostories']?.results?.length;
 
   const datasetCard = page.getByTestId('datasets-list').locator('li');
   const maxResultShown = pageLength;
@@ -40,7 +39,7 @@ test.describe('monitors and geostories display', () => {
     );
 
     const monitorsData = (await monitorsResponse.json()) as MonitorsAndGeostoriesPaginated;
-    const firstMonitorWithData = monitorsData['monitors and geostories'].find(
+    const firstMonitorWithData = monitorsData['monitors and geostories']?.results?.find(
       (monitor) => monitor.ready && monitor.description !== null
     ) as Monitor;
 
@@ -92,7 +91,7 @@ test.describe('monitors and geostories display', () => {
     );
 
     const geostoriesData = (await geostoriesResponse.json()) as MonitorsAndGeostoriesPaginated;
-    const firstGeostoryWithData = geostoriesData['monitors and geostories'].find(
+    const firstGeostoryWithData = geostoriesData['monitors and geostories']?.results?.find(
       (geostory) => geostory.ready && geostory.description !== null
     ) as Geostory;
 

--- a/e2e/datasets-hub.spec.ts
+++ b/e2e/datasets-hub.spec.ts
@@ -15,7 +15,8 @@ test('geostories and monitors display', async ({ page }) => {
 
   const datasetsData = (await datasetsResponse.json()) as MonitorsAndGeostoriesPaginated;
 
-  const pageLength = datasetsData['monitors and geostories'].length;
+  // NEW RESPONSE
+  const pageLength = datasetsData['monitors and geostories'].results.length;
 
   const datasetCard = page.getByTestId('datasets-list').locator('li');
   const maxResultShown = pageLength;

--- a/e2e/datasets-hub.spec.ts
+++ b/e2e/datasets-hub.spec.ts
@@ -10,12 +10,11 @@ test.beforeEach(async ({ page }) => {
 
 test('geostories and monitors display', async ({ page }) => {
   const datasetsResponse = await page.waitForResponse(
-    `${process.env.NEXT_PUBLIC_API_URL}monitors-and-geostories*`
+    `${process.env.NEXT_PUBLIC_API_URL}monitors-and-geostories/*`
   );
 
   const datasetsData = (await datasetsResponse.json()) as MonitorsAndGeostoriesPaginated;
-
-  const pageLength = datasetsData['monitors and geostories']?.results?.length;
+  const pageLength = datasetsData['monitors and geostories']?.['results']?.length;
 
   const datasetCard = page.getByTestId('datasets-list').locator('li');
   const maxResultShown = pageLength;
@@ -35,7 +34,7 @@ test.describe('monitors and geostories display', () => {
     await monitorsCheckbox.click();
 
     const monitorsResponse = await page.waitForResponse(
-      `${process.env.NEXT_PUBLIC_API_URL}monitors-and-geostories?type=monitors*`
+      `${process.env.NEXT_PUBLIC_API_URL}monitors-and-geostories?type=monitors/`
     );
 
     const monitorsData = (await monitorsResponse.json()) as MonitorsAndGeostoriesPaginated;
@@ -87,7 +86,7 @@ test.describe('monitors and geostories display', () => {
     await geostoriesCheckbox.click();
 
     const geostoriesResponse = await page.waitForResponse(
-      `${process.env.NEXT_PUBLIC_API_URL}monitors-and-geostories?type=geostories*`
+      `${process.env.NEXT_PUBLIC_API_URL}monitors-and-geostories?type=geostories/`
     );
 
     const geostoriesData = (await geostoriesResponse.json()) as MonitorsAndGeostoriesPaginated;

--- a/e2e/datasets-hub.spec.ts
+++ b/e2e/datasets-hub.spec.ts
@@ -10,7 +10,7 @@ test.beforeEach(async ({ page }) => {
 
 test('geostories and monitors display', async ({ page }) => {
   const datasetsResponse = await page.waitForResponse(
-    'https://g3w.earthmonitor.org/dev/monitors-and-geostories*'
+    `${process.env.NEXT_PUBLIC_API_URL}monitors-and-geostories*`
   );
 
   const datasetsData = (await datasetsResponse.json()) as MonitorsAndGeostoriesPaginated;
@@ -35,7 +35,7 @@ test.describe('monitors and geostories display', () => {
     await monitorsCheckbox.click();
 
     const monitorsResponse = await page.waitForResponse(
-      'https://g3w.earthmonitor.org/dev/monitors-and-geostories?type=monitors*'
+      `${process.env.NEXT_PUBLIC_API_URL}monitors-and-geostories?type=monitors*`
     );
 
     const monitorsData = (await monitorsResponse.json()) as MonitorsAndGeostoriesPaginated;
@@ -87,7 +87,7 @@ test.describe('monitors and geostories display', () => {
     await geostoriesCheckbox.click();
 
     const geostoriesResponse = await page.waitForResponse(
-      'https://g3w.earthmonitor.org/dev/monitors-and-geostories?type=geostories*'
+      `${process.env.NEXT_PUBLIC_API_URL}monitors-and-geostories?type=geostories*`
     );
 
     const geostoriesData = (await geostoriesResponse.json()) as MonitorsAndGeostoriesPaginated;

--- a/e2e/datasets.spec.ts
+++ b/e2e/datasets.spec.ts
@@ -8,7 +8,8 @@ test.beforeEach(async ({ page }) => {
 });
 
 test('datasets tab', async ({ page }) => {
-  const monitorsResponse = await page.waitForResponse(`${process.env.NEXT_PUBLIC_API_URL}monitors`);
+  const monitorsResponse = await page.waitForResponse(`https://g3w.earthmonitor.org/dev/monitors/`);
+
   const monitorsData = (await monitorsResponse.json()) as Monitor[];
   await page.getByTestId(`monitor-item-${monitorsData[0].id}`).click();
   await page.waitForURL('**/map/**/datasets', { waitUntil: 'load' });
@@ -20,13 +21,13 @@ test('datasets tab', async ({ page }) => {
 });
 
 test('datasets list', async ({ page }) => {
-  const monitorsResponse = await page.waitForResponse(`${process.env.NEXT_PUBLIC_API_URL}monitors`);
+  const monitorsResponse = await page.waitForResponse(`https://g3w.earthmonitor.org/dev/monitors/`);
   const monitorsData = (await monitorsResponse.json()) as Monitor[];
   await page.getByTestId(`monitor-item-${monitorsData[0].id}`).click();
   await page.waitForURL('**/map/**/datasets', { waitUntil: 'load' });
 
   const layersResponse = await page.waitForResponse(
-    `${process.env.NEXT_PUBLIC_API_URL}monitors/${monitorsData[0].id}/layers`
+    `https://g3w.earthmonitor.org/dev/monitors/${monitorsData[0].id}/layers/`
   );
   const layersData = (await layersResponse.json()) as Layer[];
   const datasetsList = page.getByTestId('datasets-list').locator('li');
@@ -37,7 +38,7 @@ test('datasets list', async ({ page }) => {
 // TODO: once we know monitors with datasets, we can test this in a better way
 test('datasets item', async ({ page }) => {
   const monitorsResponse = await page.waitForResponse(
-    `${process.env.NEXT_PUBLIC_API_URL}monitors*`
+    `https://g3w.earthmonitor.org/dev/monitors*/`
   );
   const monitorsData = (await monitorsResponse.json()) as Monitor[];
   // Find a monitor with layers (m1)
@@ -47,7 +48,7 @@ test('datasets item', async ({ page }) => {
   await page.waitForURL('**/map/**/datasets*', { waitUntil: 'load' });
 
   const layersResponse = await page.waitForResponse(
-    `${process.env.NEXT_PUBLIC_API_URL}monitors/${firstMonitorWithLayers.id}/layers`
+    `https://g3w.earthmonitor.org/dev/monitors/${firstMonitorWithLayers.id}/layers/`
   );
   const layersData = (await layersResponse.json()) as Layer[];
   const firstDataset = page.getByTestId(`dataset-item-${layersData[0].layer_id}`);

--- a/e2e/datasets.spec.ts
+++ b/e2e/datasets.spec.ts
@@ -8,8 +8,7 @@ test.beforeEach(async ({ page }) => {
 });
 
 test('datasets tab', async ({ page }) => {
-  const monitorsResponse = await page.waitForResponse('https://g3w.earthmonitor.org/dev
-/monitors');
+  const monitorsResponse = await page.waitForResponse(`${process.env.NEXT_PUBLIC_API_URL}monitors`);
   const monitorsData = (await monitorsResponse.json()) as Monitor[];
   await page.getByTestId(`monitor-item-${monitorsData[0].id}`).click();
   await page.waitForURL('**/map/**/datasets', { waitUntil: 'load' });
@@ -21,15 +20,13 @@ test('datasets tab', async ({ page }) => {
 });
 
 test('datasets list', async ({ page }) => {
-  const monitorsResponse = await page.waitForResponse('https://g3w.earthmonitor.org/dev
-/monitors');
+  const monitorsResponse = await page.waitForResponse(`${process.env.NEXT_PUBLIC_API_URL}monitors`);
   const monitorsData = (await monitorsResponse.json()) as Monitor[];
   await page.getByTestId(`monitor-item-${monitorsData[0].id}`).click();
   await page.waitForURL('**/map/**/datasets', { waitUntil: 'load' });
 
   const layersResponse = await page.waitForResponse(
-    `https://g3w.earthmonitor.org/dev
-/monitors/${monitorsData[0].id}/layers`
+    `${process.env.NEXT_PUBLIC_API_URL}monitors/${monitorsData[0].id}/layers`
   );
   const layersData = (await layersResponse.json()) as Layer[];
   const datasetsList = page.getByTestId('datasets-list').locator('li');
@@ -39,8 +36,9 @@ test('datasets list', async ({ page }) => {
 
 // TODO: once we know monitors with datasets, we can test this in a better way
 test('datasets item', async ({ page }) => {
-  const monitorsResponse = await page.waitForResponse('https://g3w.earthmonitor.org/dev
-/monitors*');
+  const monitorsResponse = await page.waitForResponse(
+    `${process.env.NEXT_PUBLIC_API_URL}monitors*`
+  );
   const monitorsData = (await monitorsResponse.json()) as Monitor[];
   // Find a monitor with layers (m1)
   const firstMonitorWithLayers = monitorsData.find((monitor) => monitor.id === 'm2');
@@ -49,8 +47,7 @@ test('datasets item', async ({ page }) => {
   await page.waitForURL('**/map/**/datasets*', { waitUntil: 'load' });
 
   const layersResponse = await page.waitForResponse(
-    `https://g3w.earthmonitor.org/dev
-/monitors/${firstMonitorWithLayers.id}/layers`
+    `${process.env.NEXT_PUBLIC_API_URL}monitors/${firstMonitorWithLayers.id}/layers`
   );
   const layersData = (await layersResponse.json()) as Layer[];
   const firstDataset = page.getByTestId(`dataset-item-${layersData[0].layer_id}`);

--- a/e2e/geostories.spec.ts
+++ b/e2e/geostories.spec.ts
@@ -10,8 +10,9 @@ test.beforeEach(async ({ page }) => {
 
 test.describe('geostories tab', () => {
   test('from /map/{monitor_id}/datasets', async ({ page }) => {
-    const monitorsResponse = await page.waitForResponse('https://g3w.earthmonitor.org/dev
-/monitors');
+    const monitorsResponse = await page.waitForResponse(
+      `${process.env.NEXT_PUBLIC_API_URL}monitors`
+    );
     const monitorsData = (await monitorsResponse.json()) as Monitor[];
     const firstMonitorWithGeostories = monitorsData.find(
       (monitor) => monitor.geostories.length > 0
@@ -42,8 +43,7 @@ test.describe('geostories tab', () => {
 
     // check geostories list is visible
     const geostoriesResponse = await page.waitForResponse(
-      `https://g3w.earthmonitor.org/dev
-/monitors/${firstMonitorWithGeostories.id}/geostories`
+      `${process.env.NEXT_PUBLIC_API_URL}monitors/${firstMonitorWithGeostories.id}/geostories`
     );
     const geostoriesData = (await geostoriesResponse.json()) as Geostory[];
     await expect(page.getByTestId('geostories-list')).toBeVisible();
@@ -65,8 +65,9 @@ test.describe('geostories tab', () => {
   });
 
   test('display monitor info in geostories tab', async ({ page }) => {
-    const monitorsFetchResponse = page.waitForResponse('https://g3w.earthmonitor.org/dev
-/monitors');
+    const monitorsFetchResponse = page.waitForResponse(
+      `${process.env.NEXT_PUBLIC_API_URL}monitors`
+    );
     const response = await monitorsFetchResponse;
     const monitorsData = (await response.json()) as Monitor[];
     const firstMonitorWithGeostories = monitorsData.find(
@@ -93,8 +94,7 @@ test.describe('geostories tab', () => {
       waitUntil: 'load',
     });
     await page.waitForResponse(
-      `https://g3w.earthmonitor.org/dev
-/monitors/${firstMonitorWithGeostories.id}/geostories`
+      `${process.env.NEXT_PUBLIC_API_URL}monitors/${firstMonitorWithGeostories.id}/geostories`
     );
 
     // check monitor info is visible
@@ -110,8 +110,9 @@ test.describe('geostories tab', () => {
   });
 
   test('display datasets from a geostory', async ({ page }) => {
-    const monitorsResponse = await page.waitForResponse('https://g3w.earthmonitor.org/dev
-/monitors');
+    const monitorsResponse = await page.waitForResponse(
+      `${process.env.NEXT_PUBLIC_API_URL}monitors`
+    );
     const monitorsData = (await monitorsResponse.json()) as Monitor[];
     const firstMonitorWithGeostories = monitorsData.find(
       (monitor) => monitor.geostories.length > 0
@@ -120,8 +121,7 @@ test.describe('geostories tab', () => {
     await page.goto(`/map/${firstMonitorWithGeostories.id}/geostories`, { waitUntil: 'load' });
 
     const geostoriesFetchResponse = page.waitForResponse(
-      `https://g3w.earthmonitor.org/dev
-/monitors/${firstMonitorWithGeostories.id}/geostories`
+      `${process.env.NEXT_PUBLIC_API_URL}monitors/${firstMonitorWithGeostories.id}/geostories`
     );
     const geostoriesResponse = await geostoriesFetchResponse;
     await expect(page.getByTestId('geostories-list')).toBeVisible();
@@ -153,8 +153,7 @@ test.describe('geostories tab', () => {
 
     // TO - DO : check if the datasets are the same as the ones in the geostory
     // const layersResponse = await page.waitForResponse(
-    //   `https://g3w.earthmonitor.org/dev
-/geostories/${geostoriesData[0].id}`
+    //     `${process.env.NEXT_PUBLIC_API_URL}`geostories/${geostoriesData[0].id}`
     // );
 
     // const layersData = (await layersResponse.json()) as Layer[];
@@ -168,8 +167,7 @@ test.describe('geostories tab', () => {
 test('From a selected geostory, user should be able to go back to the monitor it belongs', async ({
   page,
 }) => {
-  const monitorsResponse = await page.waitForResponse('https://g3w.earthmonitor.org/dev
-/monitors');
+  const monitorsResponse = await page.waitForResponse(`${process.env.NEXT_PUBLIC_API_URL}monitors`);
   const monitorsData = (await monitorsResponse.json()) as Monitor[];
   const firstMonitorWithGeostories = monitorsData.find((monitor) => monitor.geostories.length > 0);
 
@@ -192,8 +190,7 @@ test('From a selected geostory, user should be able to go back to the monitor it
 
   // check geostories list is visible
   const geostoriesResponse = await page.waitForResponse(
-    `https://g3w.earthmonitor.org/dev
-/monitors/${firstMonitorWithGeostories.id}/geostories`
+    `${process.env.NEXT_PUBLIC_API_URL}monitors/${firstMonitorWithGeostories.id}/geostories`
   );
   const geostoriesData = (await geostoriesResponse.json()) as Geostory[];
   await expect(page.getByTestId('geostories-list')).toBeVisible();

--- a/e2e/geostories.spec.ts
+++ b/e2e/geostories.spec.ts
@@ -1,7 +1,6 @@
 import { test, expect } from '@playwright/test';
 
 import type { Geostory } from '@/types/geostories';
-import type { Layer } from '@/types/layers';
 import type { Monitor } from '@/types/monitors';
 
 test.beforeEach(async ({ page }) => {
@@ -11,7 +10,7 @@ test.beforeEach(async ({ page }) => {
 test.describe('geostories tab', () => {
   test('from /map/{monitor_id}/datasets', async ({ page }) => {
     const monitorsResponse = await page.waitForResponse(
-      `${process.env.NEXT_PUBLIC_API_URL}monitors`
+      `${process.env.NEXT_PUBLIC_API_URL}monitors/`
     );
     const monitorsData = (await monitorsResponse.json()) as Monitor[];
     const firstMonitorWithGeostories = monitorsData.find(
@@ -43,7 +42,7 @@ test.describe('geostories tab', () => {
 
     // check geostories list is visible
     const geostoriesResponse = await page.waitForResponse(
-      `${process.env.NEXT_PUBLIC_API_URL}monitors/${firstMonitorWithGeostories.id}/geostories`
+      `${process.env.NEXT_PUBLIC_API_URL}monitors/${firstMonitorWithGeostories.id}/geostories/`
     );
     const geostoriesData = (await geostoriesResponse.json()) as Geostory[];
     await expect(page.getByTestId('geostories-list')).toBeVisible();
@@ -66,7 +65,7 @@ test.describe('geostories tab', () => {
 
   test('display monitor info in geostories tab', async ({ page }) => {
     const monitorsFetchResponse = page.waitForResponse(
-      `${process.env.NEXT_PUBLIC_API_URL}monitors`
+      `${process.env.NEXT_PUBLIC_API_URL}monitors/`
     );
     const response = await monitorsFetchResponse;
     const monitorsData = (await response.json()) as Monitor[];
@@ -111,7 +110,7 @@ test.describe('geostories tab', () => {
 
   test('display datasets from a geostory', async ({ page }) => {
     const monitorsResponse = await page.waitForResponse(
-      `${process.env.NEXT_PUBLIC_API_URL}monitors`
+      `${process.env.NEXT_PUBLIC_API_URL}monitors/`
     );
     const monitorsData = (await monitorsResponse.json()) as Monitor[];
     const firstMonitorWithGeostories = monitorsData.find(
@@ -121,7 +120,7 @@ test.describe('geostories tab', () => {
     await page.goto(`/map/${firstMonitorWithGeostories.id}/geostories`, { waitUntil: 'load' });
 
     const geostoriesFetchResponse = page.waitForResponse(
-      `${process.env.NEXT_PUBLIC_API_URL}monitors/${firstMonitorWithGeostories.id}/geostories`
+      `${process.env.NEXT_PUBLIC_API_URL}monitors/${firstMonitorWithGeostories.id}/geostories/`
     );
     const geostoriesResponse = await geostoriesFetchResponse;
     await expect(page.getByTestId('geostories-list')).toBeVisible();
@@ -167,7 +166,9 @@ test.describe('geostories tab', () => {
 test('From a selected geostory, user should be able to go back to the monitor it belongs', async ({
   page,
 }) => {
-  const monitorsResponse = await page.waitForResponse(`${process.env.NEXT_PUBLIC_API_URL}monitors`);
+  const monitorsResponse = await page.waitForResponse(
+    `${process.env.NEXT_PUBLIC_API_URL}monitors/`
+  );
   const monitorsData = (await monitorsResponse.json()) as Monitor[];
   const firstMonitorWithGeostories = monitorsData.find((monitor) => monitor.geostories.length > 0);
 
@@ -190,7 +191,7 @@ test('From a selected geostory, user should be able to go back to the monitor it
 
   // check geostories list is visible
   const geostoriesResponse = await page.waitForResponse(
-    `${process.env.NEXT_PUBLIC_API_URL}monitors/${firstMonitorWithGeostories.id}/geostories`
+    `${process.env.NEXT_PUBLIC_API_URL}monitors/${firstMonitorWithGeostories.id}/geostories/`
   );
   const geostoriesData = (await geostoriesResponse.json()) as Geostory[];
   await expect(page.getByTestId('geostories-list')).toBeVisible();

--- a/e2e/map.spec.ts
+++ b/e2e/map.spec.ts
@@ -5,8 +5,7 @@ test('legend', async ({ page }) => {
   await page.goto('/map/m1/datasets?layers=[{"id":"l1","opacity":1,"date":"20000101_20001231"}]', {
     waitUntil: 'load',
   });
-  await page.waitForResponse('https://g3w.earthmonitor.org/dev
-/layers?layer_id=l1');
+  await page.waitForResponse(`${process.env.NEXT_PUBLIC_API_URL}layers?layer_id=l1`);
   await expect(page.getByTestId('map-legend')).toBeVisible();
 
   // should be 1 layer in the legend

--- a/e2e/map.spec.ts
+++ b/e2e/map.spec.ts
@@ -5,6 +5,7 @@ test('legend', async ({ page }) => {
   await page.goto('/map/m1/datasets?layers=[{"id":"l1","opacity":1,"date":"20000101_20001231"}]', {
     waitUntil: 'load',
   });
+
   await page.waitForResponse(`${process.env.NEXT_PUBLIC_API_URL}layers?layer_id=l1`);
   await expect(page.getByTestId('map-legend')).toBeVisible();
 

--- a/e2e/monitors.spec.ts
+++ b/e2e/monitors.spec.ts
@@ -8,8 +8,7 @@ test.beforeEach(async ({ page }) => {
 
 // test.describe('monitors navigation', () => {
 //   test('from modal in /map', async ({ page }) => {
-//     const response = await page.waitForResponse('https://g3w.earthmonitor.org/dev
-/monitors');
+//     const response = await page.waitForResponse(  `${process.env.NEXT_PUBLIC_API_URL}monitors`);
 //     const json = (await response.json()) as Monitor[];
 //     const monitorsIds = json
 //       .filter((monitor) => monitor.ready && monitor.description !== null)
@@ -30,8 +29,7 @@ test.beforeEach(async ({ page }) => {
 //   });
 //   // TO - DO - add back
 //   // test('from modal in /map/{monitor_id}/datasets', async ({ page }) => {
-//   //   const monitorsFetchResponse = page.waitForResponse('https://g3w.earthmonitor.org/dev
-/monitors');
+//   //   const monitorsFetchResponse = page.waitForResponse('https://g3w.earthmonitor.org/dev/monitors');
 //   //   const response = await monitorsFetchResponse;
 //   //   const json = (await response.json()) as Monitor[];
 //   //   const monitorsIds = json

--- a/e2e/search.spec.ts
+++ b/e2e/search.spec.ts
@@ -27,13 +27,13 @@ test.describe('search of monitors and geostories', () => {
       await expect(page.getByTestId('datasets-result')).toHaveText('1 result');
     } else if (filteredJson['monitors and geostories'].length > 1) {
       await expect(page.getByTestId('datasets-result')).toHaveText(
-        `${filteredJson['monitors and geostories'].length} results`
+        `${filteredJson['monitors and geostories']['results'].length} results`
       );
     }
 
     // check that the no results disclaimer is displayed
     const noResultsDisclaimer = page.getByTestId('no-results-found');
-    if (!filteredJson['monitors and geostories'].length) {
+    if (!filteredJson['monitors and geostories']['results'].length) {
       await expect(noResultsDisclaimer).toBeVisible();
     }
   });

--- a/e2e/share-tool.spec.ts
+++ b/e2e/share-tool.spec.ts
@@ -4,7 +4,9 @@ import type { Monitor } from 'types/monitors';
 
 test.beforeEach(async ({ page }) => {
   await page.goto('/map', { waitUntil: 'load' });
-  const monitorsResponse = await page.waitForResponse(`${process.env.NEXT_PUBLIC_API_URL}monitors`);
+  const monitorsResponse = await page.waitForResponse(
+    `${process.env.NEXT_PUBLIC_API_URL}monitors/`
+  );
   const monitorsData = (await monitorsResponse.json()) as Monitor[];
   await page.getByTestId(`monitor-item-${monitorsData[0].id}`).click();
   await page.waitForURL('**/map/**/datasets', { waitUntil: 'load' });

--- a/e2e/share-tool.spec.ts
+++ b/e2e/share-tool.spec.ts
@@ -4,8 +4,7 @@ import type { Monitor } from 'types/monitors';
 
 test.beforeEach(async ({ page }) => {
   await page.goto('/map', { waitUntil: 'load' });
-  const monitorsResponse = await page.waitForResponse('https://g3w.earthmonitor.org/dev
-/monitors');
+  const monitorsResponse = await page.waitForResponse(`${process.env.NEXT_PUBLIC_API_URL}monitors`);
   const monitorsData = (await monitorsResponse.json()) as Monitor[];
   await page.getByTestId(`monitor-item-${monitorsData[0].id}`).click();
   await page.waitForURL('**/map/**/datasets', { waitUntil: 'load' });

--- a/e2e/sort.spec.ts
+++ b/e2e/sort.spec.ts
@@ -15,11 +15,7 @@
 //   // test('sort by id', async ({ page }) => {
 //   //   const response = await page.waitForResponse(
 //   //     'https://g3w.earthmonitor.org/dev
-<<<<<<< HEAD
-/monitors-and-geostories?sort_by=title'
-=======
 // /monitors-and-geostories?sort_by=title'
->>>>>>> 3d31b60 (monitors and geostories endpoint renamed)
 //   //   );
 
 //   //   const defaultOrderedDataByTitle = (await response.json()) as MonitorsAndGeostoriesResponse[];
@@ -27,13 +23,8 @@
 
 //   //   await sortByIdCheckbox.click();
 //   //   const sortPromise = page.waitForResponse(
-<<<<<<< HEAD
-//   //     'https://g3w.earthmonitor.org/dev
-/monitors-and-geostories?sort_by=id'
-=======
 // //   //     'https://g3w.earthmonitor.org/dev
 // /monitors-and-geostories?sort_by=id'
->>>>>>> 3d31b60 (monitors and geostories endpoint renamed)
 //   //   );
 //   //   const sortedResponse = await sortPromise;
 //   //   const sortedByIdResponse = (await sortedResponse.json()) as MonitorsAndGeostoriesResponse[];
@@ -48,11 +39,7 @@
 //   test('sort by date', async ({ page }) => {
 //     const response = await page.waitForResponse(
 //       'https://g3w.earthmonitor.org/dev
-<<<<<<< HEAD
-/monitors-and-geostories?*sort_by=title*'
-=======
 // /monitors-and-geostories?*sort_by=title*'
->>>>>>> 3d31b60 (monitors and geostories endpoint renamed)
 //     );
 
 //     const defaultOrderedDataByTitle = (await response.json()) as PaginatedResponse;
@@ -61,11 +48,7 @@
 //     await sortByDateCheckbox.click();
 //     const sortPromise = page.waitForResponse(
 //       'https://g3w.earthmonitor.org/dev
-<<<<<<< HEAD
-/monitors-and-geostories?*sort_by=date'
-=======
 // /monitors-and-geostories?*sort_by=date'
->>>>>>> 3d31b60 (monitors and geostories endpoint renamed)
 //     );
 //     const sortedResponse = await sortPromise;
 //     const sortedByDateResponse = (await sortedResponse.json()) as PaginatedResponse;
@@ -80,11 +63,7 @@
 //   test('sort by title (default option)', async ({ page }) => {
 //     const response = await page.waitForResponse(
 //       'https://g3w.earthmonitor.org/dev
-<<<<<<< HEAD
-/monitors-and-geostories?sort_by=title'
-=======
 // /monitors-and-geostories?sort_by=title'
->>>>>>> 3d31b60 (monitors and geostories endpoint renamed)
 //     );
 
 //     const defaultOrderedDataByTitle = (await response.json()) as PaginatedResponse;

--- a/e2e/theme-filter.spec.ts
+++ b/e2e/theme-filter.spec.ts
@@ -17,7 +17,7 @@ test.describe('filter monitors and geostories by different theme', () => {
     await page.getByTestId('Soil-checkbox').setChecked(true);
 
     const filteredResponse = await page.waitForResponse(
-      `${process.env.NEXT_PUBLIC_API_URL}monitors-and-geostories?*theme=Soil*`
+      `${process.env.NEXT_PUBLIC_API_URL}monitors-and-geostories?*theme=Soil/*`
     );
     const filteredJson = (await filteredResponse.json()) as MonitorsAndGeostoriesPaginated;
 
@@ -41,7 +41,7 @@ test(`Filter by themes Agriculture and Climate & Health`, async ({ page, request
   await page.getByTestId('Climate & Health-checkbox').setChecked(true);
 
   const responsePromise = page.waitForResponse(
-    `${process.env.NEXT_PUBLIC_API_URL}monitors-and-geostories?*theme=Climate+%26+Health,Agriculture*`
+    `${process.env.NEXT_PUBLIC_API_URL}monitors-and-geostories?*theme=Climate+%26+Health,Agriculture*/`
   );
   const filteredResponse = await responsePromise;
   const filteredJson = (await filteredResponse.json()) as MonitorsAndGeostoriesPaginated;
@@ -83,7 +83,7 @@ test.describe('Cards and badges displayed according selected themes', () => {
     await page.getByTestId('Water-checkbox').setChecked(true);
 
     const responsePromise = page.waitForResponse(
-      `${process.env.NEXT_PUBLIC_API_URL}monitors-and-geostories?*theme=Water,Soil*`
+      `${process.env.NEXT_PUBLIC_API_URL}monitors-and-geostories?*theme=Water,Soil*/`
     );
     const filteredResponse = await responsePromise;
     const filteredJson = (await filteredResponse.json()) as MonitorsAndGeostoriesPaginated;

--- a/e2e/theme-filter.spec.ts
+++ b/e2e/theme-filter.spec.ts
@@ -9,7 +9,7 @@ test.beforeEach(async ({ page }) => {
 test.describe('filter monitors and geostories by different theme', () => {
   test('Filter by theme Soil', async ({ page, request }) => {
     const response = await request.get(
-      'https://g3w.earthmonitor.org/dev/monitors-and-geostories?theme=Soil&pagination=true'
+      `${process.env.NEXT_PUBLIC_API_URL}monitors-and-geostories?theme=Soil&pagination=true`
     );
     const datasetsData = (await response.json()) as MonitorsAndGeostoriesPaginated;
 
@@ -17,11 +17,11 @@ test.describe('filter monitors and geostories by different theme', () => {
     await page.getByTestId('Soil-checkbox').setChecked(true);
 
     const filteredResponse = await page.waitForResponse(
-      `https://g3w.earthmonitor.org/dev/monitors-and-geostories?*theme=Soil*`
+      `${process.env.NEXT_PUBLIC_API_URL}monitors-and-geostories?*theme=Soil*`
     );
     const filteredJson = (await filteredResponse.json()) as MonitorsAndGeostoriesPaginated;
 
-    expect(filteredJson['monitors and geostories']).toEqual(
+    expect(filteredJson['monitors and geostories']['results']).toEqual(
       datasetsData['monitors and geostories']
     );
 
@@ -32,7 +32,7 @@ test.describe('filter monitors and geostories by different theme', () => {
 
 test(`Filter by themes Agriculture and Climate & Health`, async ({ page, request }) => {
   const response = await request.get(
-    'https://g3w.earthmonitor.org/dev/monitors-and-geostories?theme=Climate+%26+Health,Agriculture&pagination=true'
+    `${process.env.NEXT_PUBLIC_API_URL}monitors-and-geostories?theme=Climate+%26+Health,Agriculture&pagination=true`
   );
   const datasetsData = (await response.json()) as MonitorsAndGeostoriesPaginated;
 
@@ -41,7 +41,7 @@ test(`Filter by themes Agriculture and Climate & Health`, async ({ page, request
   await page.getByTestId('Climate & Health-checkbox').setChecked(true);
 
   const responsePromise = page.waitForResponse(
-    `https://g3w.earthmonitor.org/dev/monitors-and-geostories?*theme=Climate+%26+Health,Agriculture*`
+    `${process.env.NEXT_PUBLIC_API_URL}monitors-and-geostories?*theme=Climate+%26+Health,Agriculture*`
   );
   const filteredResponse = await responsePromise;
   const filteredJson = (await filteredResponse.json()) as MonitorsAndGeostoriesPaginated;
@@ -55,7 +55,7 @@ test(`Filter by themes Agriculture and Climate & Health`, async ({ page, request
 
 test(`Filter by themes Soil and Water`, async ({ page, request }) => {
   const response = await request.get(
-    'https://g3w.earthmonitor.org/dev/monitors-and-geostories?theme=Water,Soil&pagination=true'
+    `${process.env.NEXT_PUBLIC_API_URL}monitors-and-geostories?theme=Water,Soil&pagination=true`
   );
   const datasetsData = (await response.json()) as MonitorsAndGeostoriesPaginated;
 
@@ -64,7 +64,7 @@ test(`Filter by themes Soil and Water`, async ({ page, request }) => {
   await page.getByTestId('Water-checkbox').setChecked(true);
 
   const responsePromise = page.waitForResponse(
-    `https://g3w.earthmonitor.org/dev/monitors-and-geostories?*theme=Water,Soil*`
+    `${process.env.NEXT_PUBLIC_API_URL}monitors-and-geostories?*theme=Water,Soil*`
   );
   const filteredResponse = await responsePromise;
   const filteredJson = (await filteredResponse.json()) as MonitorsAndGeostoriesPaginated;
@@ -83,7 +83,7 @@ test.describe('Cards and badges displayed according selected themes', () => {
     await page.getByTestId('Water-checkbox').setChecked(true);
 
     const responsePromise = page.waitForResponse(
-      'https://g3w.earthmonitor.org/dev/monitors-and-geostories?*theme=Water,Soil*'
+      `${process.env.NEXT_PUBLIC_API_URL}monitors-and-geostories?*theme=Water,Soil*`
     );
     const filteredResponse = await responsePromise;
     const filteredJson = (await filteredResponse.json()) as MonitorsAndGeostoriesPaginated;
@@ -105,7 +105,7 @@ test.describe('Cards and badges displayed according selected themes', () => {
     await page.getByTestId('Agriculture-checkbox').setChecked(true);
 
     const responsePromise = page.waitForResponse(
-      'https://g3w.earthmonitor.org/dev/monitors-and-geostories?*theme=Agriculture,Forest,Biodiversity*'
+      `${process.env.NEXT_PUBLIC_API_URL}monitors-and-geostories?*theme=Agriculture,Forest,Biodiversity*`
     );
     const filteredResponse = await responsePromise;
     const filteredJson = (await filteredResponse.json()) as MonitorsAndGeostoriesPaginated;

--- a/next.config.js
+++ b/next.config.js
@@ -9,7 +9,7 @@ const nextConfig = {
   output: 'standalone',
   poweredByHeader: false,
   env: {
-    API_URL: process.env.API_URL || 'https://g3w.earthmonitor.org/dev',
+    API_URL: process.env.API_URL,
   },
   images: {
     unoptimized: true,

--- a/package.json
+++ b/package.json
@@ -103,6 +103,8 @@
     "eslint-plugin-import": "^2.29.1",
     "eslint-plugin-prettier": "^4.2.1",
     "husky": "8.0.3",
+    "i": "0.3.7",
+    "next-plausible": "3.12.4",
     "next-usequerystate": "1.9.2",
     "prettier": "^2.8.8",
     "prettier-plugin-tailwindcss": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "clsx": "^2.0.0",
     "cmdk": "^1.0.0",
     "d3-format": "^3.1.0",
+    "dotenv": "^16.4.7",
     "embla-carousel-react": "^8.1.7",
     "framer-motion": "10.12.16",
     "jotai": "^2.10.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,11 @@
 import { defineConfig, devices } from '@playwright/test';
 
+import dotenv from 'dotenv';
+import path from 'path';
+
+// Read from ".env.test" file.
+dotenv.config({ path: path.resolve(__dirname, '.env.test') });
+
 /**
  * Read environment variables from file.
  * https://github.com/motdotla/dotenv
@@ -21,10 +27,13 @@ export default defineConfig({
   },
   /* Run your local dev server before starting the tests */
   webServer: {
-    command: process.env.CI ? 'yarn build && yarn start' : 'yarn dev',
+    command: process.env.CI ? 'yarn build && yarn start' : 'NODE_ENV=test && yarn dev',
     url: `http://localhost:${PORT}`,
     reuseExistingServer: !process.env.CI,
     timeout: 120000,
+    env: {
+      NEXT_PUBLIC_API_URL: 'https://g3w.earthmonitor.org/dev/',
+    },
   },
   /* Run tests in files in parallel */
   fullyParallel: !process.env.CI,
@@ -51,7 +60,7 @@ export default defineConfig({
   projects: [
     {
       name: 'Google Chrome',
-      use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+      use: { ...devices['Desktop Chrome'], channel: 'chromium' },
     },
     ...(process.env.CI
       ? []

--- a/src/components/line-chart/legend.tsx
+++ b/src/components/line-chart/legend.tsx
@@ -1,0 +1,34 @@
+import { COMPARE_DATA_COLOR, DATA_COLOR } from './utils';
+
+type ChartLegendProps = {
+  title: string;
+  compareTitle: string;
+};
+const ChartLegend = ({ title, compareTitle }: ChartLegendProps) => {
+  return (
+    <div className="mt-5">
+      <ul className="columns-2 text-[#848981]">
+        <li className="flex items-center gap-2">
+          <div
+            style={{
+              backgroundColor: DATA_COLOR,
+            }}
+            className="h-px w-8"
+          />
+          <span className="font-inter text-[10px]">{title}</span>
+        </li>
+        <li className="flex items-center gap-2">
+          <div
+            style={{
+              backgroundColor: COMPARE_DATA_COLOR,
+            }}
+            className="h-px w-8"
+          />
+          <span className="font-inter text-[10px]">{compareTitle}</span>
+        </li>
+      </ul>
+    </div>
+  );
+};
+
+export default ChartLegend;

--- a/src/components/line-chart/tooltip.tsx
+++ b/src/components/line-chart/tooltip.tsx
@@ -1,0 +1,80 @@
+import { Tooltip, defaultStyles } from '@visx/tooltip';
+import { TooltipData } from './types';
+import { format } from 'd3-format';
+import { COMPARE_DATA_COLOR, DATA_COLOR, formatDate } from './utils';
+
+const numberFormat = format(',.0f');
+
+type ChartTooltipProps = {
+  tooltipTop: number;
+  tooltipLeft: number;
+  tooltipData: TooltipData;
+  dataTitle?: string;
+  dataCompareTitle?: string;
+};
+
+const ChartTooltip = ({
+  tooltipData,
+  tooltipLeft,
+  tooltipTop,
+  dataCompareTitle,
+  dataTitle,
+}: ChartTooltipProps) => {
+  return (
+    <Tooltip
+      top={tooltipTop - 12}
+      left={tooltipLeft + 60}
+      key={Math.random()}
+      className="TOOLTIP"
+      style={{
+        ...defaultStyles,
+        backgroundColor: 'transparent',
+        color: 'white',
+        borderRadius: '4px',
+      }}
+    >
+      <div className="bg-brand-500/80 p-2">
+        <div>
+          <p className="font-satoshi text-[10px] font-bold">
+            {!!tooltipData && formatDate(tooltipData.x)}
+          </p>
+          <div className="flex items-center justify-between gap-3">
+            {dataCompareTitle && (
+              <>
+                <div
+                  style={{
+                    backgroundColor: DATA_COLOR,
+                  }}
+                  className="h-px w-5"
+                />
+                <p className="font-inter text-xs">{dataTitle}</p>
+              </>
+            )}
+            <p className="font-inter flex-1 text-end text-xs font-bold">
+              {!!tooltipData && numberFormat(tooltipData.y)}
+            </p>
+          </div>
+          {!!dataCompareTitle && (
+            <div className="mt-1 flex items-center justify-between gap-3">
+              <>
+                <div
+                  style={{
+                    backgroundColor: COMPARE_DATA_COLOR,
+                  }}
+                  className="h-px w-5"
+                />
+                <p className="font-inter text-xs">{dataCompareTitle}</p>
+              </>
+
+              <p className="font-inter flex-1 text-end text-xs font-bold">
+                {!!tooltipData.compare && numberFormat(tooltipData.compare.y)}
+              </p>
+            </div>
+          )}
+        </div>
+      </div>
+    </Tooltip>
+  );
+};
+
+export default ChartTooltip;

--- a/src/components/line-chart/types.ts
+++ b/src/components/line-chart/types.ts
@@ -1,0 +1,20 @@
+export interface DataPoint {
+  x: string | number;
+  y: number;
+}
+
+export interface TooltipData extends DataPoint {
+  region?: string;
+  compare?: Omit<TooltipData, 'compare'> & { tooltipTop: number };
+}
+
+export interface LineChartProps {
+  data: {
+    title?: string;
+    data: DataPoint[];
+  };
+  dataCompare?: {
+    title?: string;
+    data: DataPoint[];
+  };
+}

--- a/src/components/line-chart/utils.ts
+++ b/src/components/line-chart/utils.ts
@@ -1,0 +1,30 @@
+import { DataPoint } from './types';
+import { bisector } from '@visx/vendor/d3-array';
+
+export const formatDate = (value: number | string) =>
+  new Date(value).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+  });
+
+export const DATA_COLOR = '#35B6D8';
+export const COMPARE_DATA_COLOR = '#F06BAF';
+export const margin = { top: 25, right: 20, bottom: 30, left: 40 };
+export const height = 200;
+export const width = 400;
+export const colorAxis = '#2E3333';
+export const tickProps = {
+  hideTicks: true,
+  stroke: colorAxis,
+  tickStroke: colorAxis,
+  strokeWidth: 0.5,
+  tickLabelProps: {
+    fill: '#848981',
+    fontSize: 12,
+    letterSpacing: '-0.1px',
+    fontWeight: 400,
+  },
+};
+
+export const bisectDate = bisector<DataPoint, Date>((d) => new Date(d.x)).left;
+export const getDate = (d: DataPoint) => new Date(d.x);

--- a/src/components/main-menu/mobile/index.tsx
+++ b/src/components/main-menu/mobile/index.tsx
@@ -49,7 +49,6 @@ const MainMenuMobile = () => {
     if (isOpen) {
       setIsOpen(false);
     }
-    //eslint-disable-next-line
   }, [pathname]);
 
   const handleMobile = () => {
@@ -131,7 +130,7 @@ const MainMenuMobile = () => {
                   <Link
                     href="/"
                     className={cn(
-                      'flex h-full min-w-[180px] items-center justify-center p-4 text-center font-satoshi font-bold text-secondary-500 transition-colors first:border-t first:border-secondary-900 hover:bg-secondary-500 hover:text-brand-500',
+                      'font-satoshi flex h-full min-w-[180px] items-center justify-center p-4 text-center font-bold text-secondary-500 transition-colors first:border-t first:border-secondary-900 hover:bg-secondary-500 hover:text-brand-500',
                       {
                         'hover:bg-secondary-500  hover:text-brand-500':
                           `/${pathname.split('/')[1]}` === '/',
@@ -143,7 +142,7 @@ const MainMenuMobile = () => {
                   </Link>
                   <button
                     type="button"
-                    className="flex h-full min-w-[180px] items-center justify-center p-4 text-center font-satoshi font-bold text-secondary-500 transition-colors first:border-t first:border-secondary-900 hover:bg-secondary-500 hover:text-brand-500"
+                    className="font-satoshi flex h-full min-w-[180px] items-center justify-center p-4 text-center font-bold text-secondary-500 transition-colors first:border-t first:border-secondary-900 hover:bg-secondary-500 hover:text-brand-500"
                     onClick={handleMapMenu}
                   >
                     Map
@@ -182,7 +181,7 @@ const MainMenuMobile = () => {
                     </Link>
                     <div
                       data-testid="alpha-site"
-                      className="rounded-sm border border-alert px-[6px] py-1 font-inter text-xs text-alert"
+                      className="font-inter rounded-sm border border-alert px-[6px] py-1 text-xs text-alert"
                     >
                       Alpha version
                     </div>

--- a/src/components/map/controls/compare-regions/index.tsx
+++ b/src/components/map/controls/compare-regions/index.tsx
@@ -11,15 +11,16 @@ import { Tooltip, TooltipArrow, TooltipContent, TooltipTrigger } from '@/compone
 
 const CompareRegionsStatistics = ({
   isMobile,
-  onClick,
-}: {
+}: // onClick,
+{
   isMobile?: boolean;
   onClick: () => void;
 }) => {
-  const [isRegionsLayerActive] = useAtom(regionsLayerVisibilityAtom);
+  const [isRegionsLayerActive, setIsRegionsLayerActive] = useAtom(regionsLayerVisibilityAtom);
   const [leftLayerHistogramVisibility, setLeftLayerHistogramVisibility] = useAtom(
     histogramLayerLeftVisibilityAtom
   );
+
   return (
     <Tooltip>
       <TooltipTrigger asChild>
@@ -27,12 +28,13 @@ const CompareRegionsStatistics = ({
           initial="initial"
           whileHover="hover"
           className={cn({
-            'group bg-brand-500': true,
+            'group bg-brand-500 stroke-secondary-500 hover:stroke-brand-500': true,
             'p-4': isMobile,
             [CONTROL_BUTTON_STYLES.mobile]: isMobile,
             [CONTROL_BUTTON_STYLES.default]: !isMobile,
+            'bg-white stroke-brand-500': isRegionsLayerActive,
           })}
-          onClick={onClick}
+          onClick={() => setIsRegionsLayerActive((prev) => !prev)}
           // disabled={leftLayerHistogramVisibility && !isRegionsLayerActive}
         >
           {
@@ -48,28 +50,28 @@ const CompareRegionsStatistics = ({
                 stroke-width="1.5"
                 stroke-linecap="round"
                 stroke-linejoin="round"
-                className="stroke-current text-secondary-500 group-hover:text-[#09131D]"
+                // className="stroke-current text-secondary-500 group-hover:text-[#09131D]"
               />
               <path
                 d="M7.5 4.20581V5.69981C7.5 6.4159 7.78446 7.10265 8.29081 7.609C8.79716 8.11535 9.48392 8.39981 10.2 8.39981C10.6774 8.39981 11.1352 8.58945 11.4728 8.92702C11.8104 9.26458 12 9.72242 12 10.1998C12 11.1898 12.81 11.9998 13.8 11.9998C14.2774 11.9998 14.7352 11.8102 15.0728 11.4726C15.4104 11.135 15.6 10.6772 15.6 10.1998C15.6 9.20981 16.41 8.39981 17.4 8.39981H20.253"
                 stroke-width="1.5"
                 stroke-linecap="round"
                 stroke-linejoin="round"
-                className="stroke-current text-secondary-500 group-hover:text-[#09131D]"
+                // // className="stroke-current text-secondary-500 group-hover:text-[#09131D]"
               />
               <path
                 d="M11.0999 20.9551V17.4001C11.0999 16.9227 10.9103 16.4649 10.5727 16.1273C10.2351 15.7897 9.77731 15.6001 9.29992 15.6001C8.82253 15.6001 8.3647 15.4105 8.02713 15.0729C7.68956 14.7353 7.49992 14.2775 7.49992 13.8001V12.9001C7.49992 12.4227 7.31028 11.9649 6.97271 11.6273C6.63515 11.2897 6.17731 11.1001 5.69992 11.1001H3.04492"
                 stroke-width="1.5"
                 stroke-linecap="round"
                 stroke-linejoin="round"
-                className="stroke-current text-secondary-500 group-hover:text-[#09131D]"
+                // className="stroke-current text-secondary-500 group-hover:text-[#09131D]"
               />
               <path
                 d="M12 21C16.9706 21 21 16.9706 21 12C21 7.02944 16.9706 3 12 3C7.02944 3 3 7.02944 3 12C3 16.9706 7.02944 21 12 21Z"
                 stroke-width="1.5"
                 stroke-linecap="round"
                 stroke-linejoin="round"
-                className="stroke-current text-secondary-500 group-hover:text-[#09131D]"
+                // className="stroke-current text-secondary-500 group-hover:text-[#09131D]"
               />
             </svg>
           }

--- a/src/components/map/geostory-map.tsx
+++ b/src/components/map/geostory-map.tsx
@@ -496,7 +496,7 @@ const Map: FC<GeostoryMapProps> = ({
           <RLayerWMS
             ref={nutsLayer}
             properties={{ label: 'NUTS' }}
-            url="https://v2-geoserver.openlandmap.org/geoserver/oem/wms"
+            url="https://geoserver.earthmonitor.org/geoserver/oem/wms"
             opacity={0.2}
             params={{
               FORMAT: 'image/png',

--- a/src/components/map/index.tsx
+++ b/src/components/map/index.tsx
@@ -376,7 +376,7 @@ const Map: FC<CustomMapProps> = ({ initialViewState = DEFAULT_VIEWPORT }) => {
           <RLayerWMS
             ref={nutsLayer}
             properties={{ label: 'NUTS' }}
-            url="https://v2-geoserver.openlandmap.org/geoserver/oem/wms"
+            url="https://geoserver.earthmonitor.org/geoserver/oem/wms"
             opacity={0.2}
             params={{
               FORMAT: 'image/png',

--- a/src/components/map/stats/point-histogram.tsx
+++ b/src/components/map/stats/point-histogram.tsx
@@ -62,7 +62,7 @@ const PointHistogram: FC<HistogramTypes> = ({
     lon: lonLat?.[0] || 0,
     lat: lonLat?.[1] || 0,
     layer_id: layerId,
-    coll: srv_path,
+    srv_path,
     regex,
   };
 
@@ -74,31 +74,20 @@ const PointHistogram: FC<HistogramTypes> = ({
   );
 
   const histogramPointData = useMemo(() => {
-    if (!histogramData) return [];
-    if (Array.isArray(histogramData)) {
-      return histogramData.map((d) => ({
-        x: d.label,
-        y: d.value,
-      }));
-    } else {
-      (histogramData &&
-        Object.entries(histogramData)?.map(([label, value]) => {
-          const d1 = label.split('_')[0];
-          const date = d1.slice(0, 4) + '/' + d1.slice(4, 6) + '/' + d1.slice(6, 8);
-          return {
-            x: date,
-            y: value,
-          };
-        })) ||
-        [];
-    }
+    return {
+      data:
+        (histogramData || []).map((d) => ({
+          x: d.label,
+          y: d.value,
+        })) || [],
+    };
   }, [histogramData]);
 
   const handleClick = useCallback(() => {
     if (histogramData) {
       const data = Array.isArray(histogramData)
         ? histogramData
-        : histogramPointData?.map((d) => ({
+        : histogramPointData?.data?.map((d) => ({
             layer_id: layerId,
             label: d.x,
             value: d.y,
@@ -117,14 +106,14 @@ const PointHistogram: FC<HistogramTypes> = ({
         'left-[570px]': isSidebarOpen,
       })}
     >
-      <div className="first-letter:text-2xs border border-secondary-900 bg-brand-500 p-4 shadow-md">
+      <div className="first-letter:text-2xs border border-secondary-900 bg-brand-500 p-5 shadow-md">
         <button className="absolute right-4 top-4 z-50" onClick={onCloseTooltip}>
           <XIcon size={14} />
         </button>
         <div className="relative space-y-2">
-          <div className="font-satoshi mr-5 space-y-4 font-bold">
+          <div className="font-satoshi space-y-4 font-bold">
             <div>
-              <h3 className="text-sm">{leftData.title}</h3>
+              <h3 className="mb-2 text-sm">{leftData.title}</h3>
               <h4 className="text-2xl">
                 Location {numberFormat(lonLat[0])}, {numberFormat(lonLat[1])}
               </h4>

--- a/src/components/map/types.d.ts
+++ b/src/components/map/types.d.ts
@@ -90,3 +90,19 @@ export type GeostoryMapProps = CustomMapProps & {
   layerData: LayerParsed;
   compareLayerData: LayerParsed;
 };
+
+export type NutsProperties = {
+  CNTR_CODE: string;
+  NAME_LATN: string;
+};
+
+export type NutsDataset = {
+  avg: number;
+  label: string;
+  max: number;
+  min: number;
+};
+
+export type NuqsData = {
+  dataset: NutsDataset[];
+};

--- a/src/components/map/utils.ts
+++ b/src/components/map/utils.ts
@@ -1,0 +1,69 @@
+import { Coordinate } from 'ol/coordinate';
+import { TileWMS } from 'ol/source';
+import { FeatureInfoResponse, NuqsData } from './types';
+import axios from 'axios';
+
+export const getHistogramData = async (
+  wmsNutsSource: TileWMS,
+  coordinate: Coordinate,
+  resolution: number,
+  layerId: string
+) => {
+  try {
+    const NUTS_layer = wmsNutsSource?.getFeatureInfoUrl(coordinate, resolution, 'EPSG:3857', {
+      INFO_FORMAT: 'application/json',
+      LAYERS: 'oem:NUTS_RG_01M_2021_3035',
+    });
+
+    if (!NUTS_layer) {
+      console.error('Failed to generate the URL for NUTS layer.');
+      return;
+    }
+
+    const NUTS_layer_response = await axios.get<FeatureInfoResponse>(NUTS_layer);
+    const properties = NUTS_layer_response?.data?.features?.[0]?.properties;
+    if (properties) {
+      return {
+        properties,
+        nutsDataParams: {
+          NUTS_ID: properties?.NUTS_ID as string,
+          LAYER_ID: layerId,
+        },
+      };
+    }
+    return {};
+  } catch {
+    console.error('There had been an error while fetching NUTS layer data');
+    return {};
+  }
+};
+
+const isValidDate = (dateStr: string) => {
+  const date = new Date(dateStr);
+  return date instanceof Date && !isNaN(date.getTime());
+};
+
+export const transformNuqsData = (data: NuqsData) => {
+  return (
+    data?.dataset?.reduce((acc, { label, avg, max, min }) => {
+      if (Number.isNaN(Number(avg))) return acc;
+      let date = label;
+      if (!isValidDate(label)) {
+        const range = label.split('-');
+        if (isValidDate(range[0])) {
+          date = range[0];
+        }
+      }
+
+      return [
+        ...acc,
+        {
+          x: date,
+          y: avg,
+          max,
+          min,
+        },
+      ];
+    }, []) || []
+  );
+};

--- a/src/utils/providers.tsx
+++ b/src/utils/providers.tsx
@@ -4,6 +4,7 @@ import { useState, type FC, type PropsWithChildren } from 'react';
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
+import PlausibleProvider from 'next-plausible';
 import { Provider as JotaiProvider } from 'jotai';
 import { TooltipProvider } from '@/components/ui/tooltip';
 
@@ -24,9 +25,16 @@ const Providers: ProvidersProps = ({ children }) => {
   );
   return (
     <TooltipProvider>
-      <QueryClientProvider client={queryClient}>
-        <JotaiProvider>{children}</JotaiProvider>
-      </QueryClientProvider>
+      <PlausibleProvider
+        domain="https://app.earthmonitor.org/"
+        trackOutboundLinks
+        trackFileDownloads
+        selfHosted
+      >
+        <QueryClientProvider client={queryClient}>
+          <JotaiProvider>{children}</JotaiProvider>
+        </QueryClientProvider>
+      </PlausibleProvider>
     </TooltipProvider>
   );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -5060,6 +5060,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dotenv@npm:^16.4.7":
+  version: 16.4.7
+  resolution: "dotenv@npm:16.4.7"
+  checksum: c27419b5875a44addcc56cc69b7dc5b0e6587826ca85d5b355da9303c6fc317fc9989f1f18366a16378c9fdd9532d14117a1abe6029cc719cdbbef6eaef2cea4
+  languageName: node
+  linkType: hard
+
 "earcut@npm:^2.2.3":
   version: 2.2.4
   resolution: "earcut@npm:2.2.4"
@@ -7952,6 +7959,7 @@ __metadata:
     clsx: ^2.0.0
     cmdk: ^1.0.0
     d3-format: ^3.1.0
+    dotenv: ^16.4.7
     embla-carousel-react: ^8.1.7
     eslint: ^9.9.0
     eslint-config-next: 14.1.4

--- a/yarn.lock
+++ b/yarn.lock
@@ -6365,6 +6365,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"i@npm:0.3.7":
+  version: 0.3.7
+  resolution: "i@npm:0.3.7"
+  checksum: 97db09a9377223511bbc416f22e24ee7b90417b0a384710756b2ab74e6cbd95a93ff5856c4bdd8d12d9a74e2460fcbf895f0c2525b6ab2f7898795cb5a5743cf
+  languageName: node
+  linkType: hard
+
 "iconv-lite@npm:^0.6.2":
   version: 0.6.3
   resolution: "iconv-lite@npm:0.6.3"
@@ -7550,6 +7557,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"next-plausible@npm:3.12.4":
+  version: 3.12.4
+  resolution: "next-plausible@npm:3.12.4"
+  peerDependencies:
+    next: "^11.1.0 || ^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0 "
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: f8ae32eae3b8f4f45e1bdf1ab1aaf6be9ff184468c90253f4920a0cca01b426610c7ac85d082970e614f6f05b3679b9e68aae13ee5081a3d5bd003baaf11005a
+  languageName: node
+  linkType: hard
+
 "next-usequerystate@npm:1.9.2":
   version: 1.9.2
   resolution: "next-usequerystate@npm:1.9.2"
@@ -7942,10 +7960,12 @@ __metadata:
     eslint-plugin-prettier: ^4.2.1
     framer-motion: 10.12.16
     husky: 8.0.3
+    i: 0.3.7
     jotai: ^2.10.0
     lodash-es: ^4.17.21
     lucide-react: ^0.257.0
     next: 14.1.4
+    next-plausible: 3.12.4
     next-usequerystate: 1.9.2
     ol: 9.0.0
     ol-ext: ^4.0.11


### PR DESCRIPTION
## Histogram chart - compare regions

### Overview

This PR adds the compare regions in region histogram chart and updates the histogram chart styles

### Designs

[design](https://www.figma.com/design/G3qygCzHDtdVaHdzudoH0G/Open-Earth-Monitor---Prototype-%5BShared%5D---September?node-id=1910-3555&m=dev)

### Testing instructions

1. Select a point on the map. Click see point histogram. The chart style should be similar to the designs
2. Select the regions layer. Select and click on a region. Click 'see region histogram'. The chart style should be similar to the designs
3. Click the 'compare' button. Select another region on the map. Both regions should be displayed on the chart with the styles similar to the design.
4. The download csv should be working


## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] Update CHANGELOG
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist 

