### PR TITLE
units to csv

### DIFF
--- a/src/components/map/stats/point-histogram.tsx
+++ b/src/components/map/stats/point-histogram.tsx
@@ -79,6 +79,7 @@ const PointHistogram: FC<HistogramTypes> = ({
         (histogramData || [])?.map((d) => ({
           x: d.label,
           y: d.value,
+          unit: d.unit || '',
         })) || [],
     };
   }, [histogramData]);
@@ -91,6 +92,7 @@ const PointHistogram: FC<HistogramTypes> = ({
             layer_id: layerId,
             label: d.x,
             value: d.y,
+            unit: d.unit || '',
           }));
       downloadCSV(data, `data-${leftData.title}.csv`);
     } else {

--- a/src/components/map/stats/region-histogram.tsx
+++ b/src/components/map/stats/region-histogram.tsx
@@ -112,6 +112,7 @@ const RegionHistogram: FC<HistogramTypes> = ({
         layer_id: nutsDataParams.LAYER_ID,
         label: d.label,
         value: d.avg,
+        unit: leftData.unit || '',
       }));
       downloadCSV(data, `data-${leftData.title}.csv`);
     } else if (
@@ -121,6 +122,7 @@ const RegionHistogram: FC<HistogramTypes> = ({
       const data = histogramDataRegionRaw.dataset.map((d, i) => ({
         date: d.label,
         layer_id: nutsDataParams.LAYER_ID,
+        unit: leftData.unit || '',
         regionA: {
           name: nutsProperties?.NAME_LATN,
           min: d.min,
@@ -134,6 +136,7 @@ const RegionHistogram: FC<HistogramTypes> = ({
           avg: histogramDataRegionRawCompare.dataset[i].avg,
         },
       }));
+
       downloadCSVCompare(data, `data-${leftData.title}-compare.csv`);
     } else {
       console.error('No data available for download.');

--- a/src/hooks/datasets.ts
+++ b/src/hooks/datasets.ts
@@ -18,7 +18,7 @@ const getColor = (ready: boolean, theme: Theme, themeType: 'base' | 'dark' | 'li
   return THEMES_COLORS[theme][themeType] || THEMES_COLORS.Unknown[themeType];
 };
 
-type DataObject = Array<{ layer_id: string; label: string; value: number }>;
+type DataObject = Array<{ layer_id: string; label: string; value: number; unit?: string }>;
 
 type UseParams = {
   type?: 'monitors' | 'geostories' | 'all';
@@ -120,7 +120,7 @@ export const useDebounce = (value: string, delay: number) => {
 // Function to generate CSV content from JSON data
 function generateCSVContent(data: DataObject): string {
   // Define the columns for the CSV
-  const columns = ['layer_id', 'label', 'value'];
+  const columns = ['layer_id', 'label', 'value', 'unit'];
 
   // Create the CSV header row
   const headerRow = columns.join(',') + '\n';
@@ -134,7 +134,7 @@ function generateCSVContent(data: DataObject): string {
   // Create the CSV rows from the data
   const rows = data
     .map((rowData) => {
-      return `${rowData.layer_id},${rowData.label},${rowData.value}`;
+      return `${rowData.layer_id},${rowData.label},${rowData.value},${rowData.unit || ''}`;
     })
     .join('\n');
 
@@ -143,7 +143,7 @@ function generateCSVContent(data: DataObject): string {
 }
 
 // Function to download a CSV file
-export function downloadCSV(data: DataObject, filename: string = 'data.csv') {
+export function downloadCSV(data: DataObject, filename: string | 'data.csv') {
   // Generate CSV content
   const csvContent = generateCSVContent(data);
 
@@ -177,6 +177,7 @@ interface RegionData {
 interface DataObjectCompare {
   date: string;
   layer_id: string;
+  unit: string;
   regionA: RegionData;
   regionB: RegionData;
 }
@@ -187,6 +188,7 @@ function generateCSVContentCompare(data: DataObjectCompare[]): string {
   const columns = [
     'Date',
     'layer_id',
+    'unit',
     `${data[0].regionA.name} A Min`,
     `${data[0].regionA.name} A Max`,
     `${data[0].regionA.name} A Avg`,
@@ -207,7 +209,7 @@ function generateCSVContentCompare(data: DataObjectCompare[]): string {
   // Create the CSV rows from the data
   const rows = data
     .map((rowData) => {
-      return `${rowData.date},${rowData.layer_id},${rowData.regionA.min},${rowData.regionA.max},${rowData.regionA.avg},${rowData.regionB.min},${rowData.regionB.max},${rowData.regionB.avg}`;
+      return `${rowData.date},${rowData.layer_id},${rowData.unit},${rowData.regionA.min},${rowData.regionA.max},${rowData.regionA.avg},${rowData.regionB.min},${rowData.regionB.max},${rowData.regionB.avg}`;
     })
     .join('\n');
 

--- a/src/hooks/map.ts
+++ b/src/hooks/map.ts
@@ -1,6 +1,5 @@
 import { useQuery, UseQueryOptions } from '@tanstack/react-query';
 import { AxiosError, AxiosResponse } from 'axios';
-
 import { getCenter } from 'ol/extent';
 import { fromLonLat, toLonLat } from 'ol/proj';
 import View from 'ol/View';
@@ -17,6 +16,7 @@ type RegionData = {
   label: string;
   layer_id: string;
   value: number;
+  unit?: string;
 };
 
 const DEFAULT_QUERY_OPTIONS = {


### PR DESCRIPTION
This pull request introduces enhancements to the handling of histogram data and CSV generation by adding support for a new `unit` field. The changes ensure that the `unit` field is consistently included in data structures, CSV exports, and component logic, improving the clarity and usability of the exported data. Additionally, minor cleanup was performed in `src/hooks/map.ts`.

### Enhancements to histogram data handling:

* [`src/components/map/stats/point-histogram.tsx`](diffhunk://#diff-dd718d4bec399f99661cee43b6f31b842dd554c26bf6d4370f6f59dddfd04933R82): Updated the `PointHistogram` component to include the `unit` field when mapping `histogramData` and preparing data for CSV export. [[1]](diffhunk://#diff-dd718d4bec399f99661cee43b6f31b842dd554c26bf6d4370f6f59dddfd04933R82) [[2]](diffhunk://#diff-dd718d4bec399f99661cee43b6f31b842dd554c26bf6d4370f6f59dddfd04933R95)
* [`src/components/map/stats/region-histogram.tsx`](diffhunk://#diff-a2d6eaab4f857f6f728a1fae995bbd6dd24b97597aeb01c1fd9b12b126a0ad84R115): Modified the `RegionHistogram` component to include the `unit` field in multiple places, ensuring it is present in both raw and comparison datasets for CSV export. [[1]](diffhunk://#diff-a2d6eaab4f857f6f728a1fae995bbd6dd24b97597aeb01c1fd9b12b126a0ad84R115) [[2]](diffhunk://#diff-a2d6eaab4f857f6f728a1fae995bbd6dd24b97597aeb01c1fd9b12b126a0ad84R125) [[3]](diffhunk://#diff-a2d6eaab4f857f6f728a1fae995bbd6dd24b97597aeb01c1fd9b12b126a0ad84R139)

### Improvements to CSV generation:

* [`src/hooks/datasets.ts`](diffhunk://#diff-e36e989ebff68ceaa1f490dc4056e0442c92c2190ddb756771c0736ccd60538cL21-R21): Enhanced the `DataObject` and `DataObjectCompare` types to include the optional `unit` field. Updated CSV generation functions (`generateCSVContent` and `generateCSVContentCompare`) to include the `unit` field in both headers and rows. [[1]](diffhunk://#diff-e36e989ebff68ceaa1f490dc4056e0442c92c2190ddb756771c0736ccd60538cL21-R21) [[2]](diffhunk://#diff-e36e989ebff68ceaa1f490dc4056e0442c92c2190ddb756771c0736ccd60538cL123-R123) [[3]](diffhunk://#diff-e36e989ebff68ceaa1f490dc4056e0442c92c2190ddb756771c0736ccd60538cL137-R137) [[4]](diffhunk://#diff-e36e989ebff68ceaa1f490dc4056e0442c92c2190ddb756771c0736ccd60538cR180) [[5]](diffhunk://#diff-e36e989ebff68ceaa1f490dc4056e0442c92c2190ddb756771c0736ccd60538cR191) [[6]](diffhunk://#diff-e36e989ebff68ceaa1f490dc4056e0442c92c2190ddb756771c0736ccd60538cL210-R212)

### Miscellaneous cleanup:

* [`src/hooks/map.ts`](diffhunk://#diff-73f9c3ecf7d89bf44d597f4f0e3c3c7b0e91d5bb7e01ae224c23e3560c9d9e4dL3): Removed an unnecessary blank line and updated the `RegionData` type to include the optional `unit` field for consistency. [[1]](diffhunk://#diff-73f9c3ecf7d89bf44d597f4f0e3c3c7b0e91d5bb7e01ae224c23e3560c9d9e4dL3) [[2]](diffhunk://#diff-73f9c3ecf7d89bf44d597f4f0e3c3c7b0e91d5bb7e01ae224c23e3560c9d9e4dR19)

