### PR TITLE
sidebar fix

### DIFF
--- a/src/app/explore/page.tsx
+++ b/src/app/explore/page.tsx
@@ -1,15 +1,22 @@
+'use client';
+
 import type { NextPage } from 'next';
 
-import { SIDEBAR_THEME_FILTERS } from '@/constants/sidebar';
+import { SIDEBAR_THEME_FILTERS, SIDEBAR_WIDTH } from '@/constants/sidebar';
 
 import MapSidebar from '@/components/sidebar';
 import SidebarThemeFilters from '@/components/theme-filter/map-sidebar';
-import { Sidebar } from '@/components/ui/sidebar';
+import { Sidebar, useSidebar } from '@/components/ui/sidebar';
 
 const MapSidebarPage: NextPage = () => {
+  const { open } = useSidebar();
+  const left = open
+    ? SIDEBAR_THEME_FILTERS
+    : `calc(${SIDEBAR_THEME_FILTERS}px + ${SIDEBAR_WIDTH} * -1)`;
+
   return (
     <div>
-      <Sidebar className={`w-96 bg-black-400 px-9 py-12 left-[${SIDEBAR_THEME_FILTERS}px]`}>
+      <Sidebar className="left= w-96 bg-black-400 px-9 py-12" style={{ left }}>
         <SidebarThemeFilters />
         <div className="flex h-full w-full flex-col">
           <MapSidebar />

--- a/src/components/theme-filter/map-sidebar.tsx
+++ b/src/components/theme-filter/map-sidebar.tsx
@@ -10,7 +10,8 @@ import SidebarItem from './map-sidebar-item';
 const SidebarThemeFilters = () => {
   return (
     <div
-      className={`fixed bottom-0 left-0 top-0 z-10 h-screen  bg-black-500 text-white-500 w-[${SIDEBAR_THEME_FILTERS}px]`}
+      className="fixed bottom-0 left-0 top-0 z-10 h-screen  bg-black-500 text-white-500"
+      style={{ width: SIDEBAR_THEME_FILTERS }}
     >
       <div className={cn('flex w-full flex-col items-start space-y-2 py-8 text-sm text-white-500')}>
         {THEMES.map((theme) => {

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -30,6 +30,7 @@ import {
   SIDEBAR_WIDTH_MOBILE,
   SIDEBAR_WIDTH_ICON,
   SIDEBAR_KEYBOARD_SHORTCUT,
+  SIDEBAR_THEME_FILTERS,
 } from '@/constants/sidebar';
 
 import { Button } from '@/components/ui/button';
@@ -159,7 +160,7 @@ const SidebarProvider = forwardRef<
           <div
             style={
               {
-                '--sidebar-width': SIDEBAR_WIDTH,
+                '--sidebar-width': `calc(${SIDEBAR_WIDTH} + ${SIDEBAR_THEME_FILTERS}px)`,
                 '--sidebar-width-icon': SIDEBAR_WIDTH_ICON,
                 ...style,
               } as CSSProperties

--- a/src/containers/explore/logo.tsx
+++ b/src/containers/explore/logo.tsx
@@ -13,23 +13,15 @@ const LOGO_PADDING = 10;
 
 export default function MapLogo() {
   const { open } = useSidebar();
-
+  const left = open
+    ? `calc(${SIDEBAR_WIDTH} + ${SIDEBAR_THEME_FILTERS}px + ${LOGO_PADDING}px)`
+    : `calc(${SIDEBAR_THEME_FILTERS}px + ${LOGO_PADDING}px)`;
   return (
     <>
       <Link
         href="/"
-        className={cn('absolute top-7 z-10 transition-[left] duration-300 ease-in-out', {
-          'left-[98px]': !open,
-        })}
-        style={
-          open
-            ? {
-                left: `calc(${SIDEBAR_WIDTH} + ${SIDEBAR_THEME_FILTERS}px +  ${LOGO_PADDING}px)`,
-              }
-            : {
-                left: `calc(${SIDEBAR_THEME_FILTERS} + ${LOGO_PADDING}px)`,
-              }
-        }
+        className="absolute top-7 z-10 transition-[left] duration-300 ease-in-out"
+        style={{ left }}
       >
         <Image
           alt="Open-earth-monitor"


### PR DESCRIPTION
This pull request updates the sidebar and related components to improve layout consistency and responsiveness, particularly around the handling of sidebar widths and positioning. The most important changes include dynamically calculating sidebar positions and widths using constants, simplifying style logic, and ensuring consistent behavior when the sidebar is opened or closed.

**Sidebar positioning and dynamic width improvements:**

* Updated `src/app/explore/page.tsx` to calculate the sidebar's `left` position dynamically based on whether the sidebar is open, using the `SIDEBAR_THEME_FILTERS` and `SIDEBAR_WIDTH` constants. The `Sidebar` component now receives its `left` style directly, improving responsiveness.
* In `src/components/ui/sidebar.tsx`, sidebar width is now set using a `calc()` expression that combines `SIDEBAR_WIDTH` and `SIDEBAR_THEME_FILTERS`, ensuring the sidebar always has the correct width.
* Added `SIDEBAR_THEME_FILTERS` to the imports in `src/components/ui/sidebar.tsx` to support the new width calculation.

**Component style and logic simplification:**

* In `src/components/theme-filter/map-sidebar.tsx`, replaced template string class for width with a direct style prop using `SIDEBAR_THEME_FILTERS`, simplifying the logic and improving maintainability.
* Simplified the logo positioning logic in `src/containers/explore/logo.tsx` by computing the `left` style property based on sidebar state, removing redundant class and style logic.
