### PR TITLE
Fix/monitor page

### DIFF
--- a/src/app/explore/monitor/[monitor_id]/page.tsx
+++ b/src/app/explore/monitor/[monitor_id]/page.tsx
@@ -4,7 +4,7 @@ import axios from 'axios';
 
 import type { Monitor } from '@/types/monitors';
 
-import MonitorMapComponent from '@/components/datasets/page';
+import MonitorPageComponent from '@/components/monitors/page';
 
 type Props = {
   params: Promise<{ monitor_id: string }>;
@@ -29,5 +29,5 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
 export default async function ExploreMonitorMapPage({ params }: Props) {
   const { monitor_id } = await params;
-  return <MonitorMapComponent monitor_id={monitor_id} />;
+  return <MonitorPageComponent monitor_id={monitor_id} />;
 }

--- a/src/components/datasets/card/index.tsx
+++ b/src/components/datasets/card/index.tsx
@@ -126,13 +126,14 @@ const DatasetCard: FC<DatasetCardProps> = ({
           </Button>
         </div>
       )}
+
       {isActive && range && !!range.length && (
         <TimeSeries
           layerId={id}
           range={range}
           isActive={isActive}
-          defaultActive={isActive}
-          autoPlay={!isHistogramActive}
+          defaultActive={true}
+          autoPlay={true}
         />
       )}
       <div className="flex flex-col space-y-2.5 border-t border-dashed border-white-900 pt-3.5">

--- a/src/components/geostories/view/index.tsx
+++ b/src/components/geostories/view/index.tsx
@@ -24,17 +24,7 @@ const GeostoriesView: FC<GeostoriesViewProps> = ({ data, geostoryLayers }) => {
 
   return (
     <>
-      <div className="space-y-6 py-4">
-        <CardHeader
-          theme={theme}
-          title={title}
-          type="geostory"
-          color={color}
-          id={id}
-          className="space-y-4"
-          bbox={geostory_bbox}
-        />
-
+      <div className="relative space-y-6 py-3">
         <p>{description}</p>
         <div className="space-y-4">
           {/* Geostory image */}

--- a/src/components/map/tooltip/index.tsx
+++ b/src/components/map/tooltip/index.tsx
@@ -86,7 +86,7 @@ const MapTooltip: FC<TooltipProps> = ({
   return (
     <div
       className={cn({
-        'absolute z-50 max-w-[300px] translate-x-[-50%] translate-y-[-100%] rounded-[20px] bg-white-500 p-5 font-satoshi font-medium text-black-500 shadow-md':
+        'absolute z-50 min-w-[250px] max-w-[300px] translate-x-[-50%] translate-y-[-100%] rounded-[20px] bg-white-500 p-5 font-satoshi font-medium text-black-500 shadow-md':
           true,
         hidden: isHistogramActive,
       })}

--- a/src/components/monitors/page/index.tsx
+++ b/src/components/monitors/page/index.tsx
@@ -2,23 +2,26 @@
 
 import { useEffect, useMemo } from 'react';
 
-import { useGeostoryParsed, useGeostoryLayers } from '@/hooks/geostories';
+import { useMonitor, useMonitorLayers } from '@/hooks/monitors';
 import { useSyncLayersSettings, useSyncCompareLayersSettings } from '@/hooks/sync-query';
 
 import MobileExploreToolbar from '@/containers/explore/toolbar/mobile/toolbar';
 import BackToMonitorsAndGeostories from '@/containers/sidebar/back-monitors-geostories-button';
 
-import GeostoriesView from '@/components/geostories/view';
-import Loading from '@/components/loading';
-import { Sidebar, SidebarTrigger } from '@/components/ui/sidebar';
+import MonitorView from '@/components/monitors/view';
 import CardHeader from '@/components/sidebar/card-header';
-import { ScrollBar, ScrollArea } from '@/components/ui/scroll-area';
-const GeostoryPage: React.FC<{ geostory_id: string }> = ({ geostory_id }) => {
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Sidebar, SidebarTrigger } from '@/components/ui/sidebar';
+import Loading from '@/components/loading';
+
+const GeostoryPage: React.FC<{ monitor_id: string }> = ({ monitor_id }) => {
   const [layers, setLayers] = useSyncLayersSettings();
   const [compareLayers, setCompareLayers] = useSyncCompareLayersSettings();
 
-  const { data: geostoryData, isLoading: isGeostoryLoading } = useGeostoryParsed({ geostory_id });
-  const { data: layersData } = useGeostoryLayers({ geostory_id });
+  const { data: monitorData, isLoading: isLoading } = useMonitor({
+    monitor_id: monitor_id,
+  });
+  const { data: layersData } = useMonitorLayers({ monitor_id: monitor_id });
 
   // Only show layers with position right
   const geostoryLayers = useMemo(
@@ -56,14 +59,14 @@ const GeostoryPage: React.FC<{ geostory_id: string }> = ({ geostory_id }) => {
         <Sidebar className="w-96 overflow-y-auto bg-black-400 px-9 py-12">
           <ScrollArea>
             <div className="font-satoshi">
-              <div className="sticky top-0 z-10 gap-2 bg-black-400 pb-4">
+              <div className="sticky top-0 z-10 gap-2 bg-black-400 pb-4 ">
                 <BackToMonitorsAndGeostories />
-                {!isGeostoryLoading && <CardHeader type="geostory" {...geostoryData} />}
+                {!isLoading && <CardHeader type="monitor" {...monitorData} />}
               </div>
-              {isGeostoryLoading ? (
+              {isLoading ? (
                 <Loading />
               ) : (
-                <GeostoriesView data={geostoryData} geostoryLayers={geostoryLayers} />
+                <MonitorView data={monitorData} geostoryLayers={geostoryLayers} />
               )}
             </div>
           </ScrollArea>
@@ -77,10 +80,10 @@ const GeostoryPage: React.FC<{ geostory_id: string }> = ({ geostory_id }) => {
         </div>
       </div>
       <MobileExploreToolbar>
-        {isGeostoryLoading ? (
+        {isLoading ? (
           <Loading />
         ) : (
-          <GeostoriesView data={geostoryData} geostoryLayers={geostoryLayers} />
+          <MonitorView data={monitorData} geostoryLayers={geostoryLayers} />
         )}
       </MobileExploreToolbar>
     </>

--- a/src/components/monitors/view/index.tsx
+++ b/src/components/monitors/view/index.tsx
@@ -1,0 +1,54 @@
+import { FC } from 'react';
+
+import { LayerParsed } from '@/types/layers';
+import { Monitor } from '@/types/monitors';
+
+import DatasetCard from '@/components/datasets/card';
+import MonitorDialog from '@/components/monitors/dialog';
+
+interface MonitorViewProps {
+  data: Monitor & {
+    monitor_bbox: number[];
+    color: string;
+  };
+  geostoryLayers: LayerParsed[];
+}
+
+const MonitorView: FC<MonitorViewProps> = ({ data, geostoryLayers }) => {
+  const { color, description } = data || {};
+
+  return (
+    <>
+      <div className="relative space-y-6 py-3">
+        <p>{description}</p>
+        <div className="space-y-4">
+          <MonitorDialog {...data} />
+        </div>
+      </div>
+      {/* Datasets/layers cards */}
+      {!!geostoryLayers?.length ? (
+        <div className="border-t border-white-900">
+          <h2 className="py-2 font-medium">Datasets</h2>
+          <ul className="space-y-4 sm:space-y-6" data-testid="datasets-list">
+            {geostoryLayers?.map((dataset) => {
+              return (
+                <li key={dataset?.layer_id}>
+                  <DatasetCard
+                    {...dataset}
+                    id={dataset?.layer_id}
+                    isGeostory={false}
+                    color={color}
+                  />
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      ) : (
+        <p>No layers available for this monitor.</p>
+      )}
+    </>
+  );
+};
+
+export default MonitorView;

--- a/src/components/sidebar/card-header.tsx
+++ b/src/components/sidebar/card-header.tsx
@@ -51,7 +51,14 @@ const CardHeader: React.FC<CardHeaderProps> = ({
         href={`/explore/${type === 'monitor' ? 'monitor' : 'geostory'}/${id}?bbox=${bbox}`}
         onClick={handleClick}
       >
-        <h2 style={{ color }} className="text-[22px]">
+        <h2
+          style={{ color }}
+          className="relative inline-block text-[22px] 
+      before:absolute before:bottom-0 before:left-0
+      before:h-[2px] before:w-0 before:bg-current
+      before:transition-all before:duration-300
+      hover:before:w-full"
+        >
           {title}
         </h2>
       </Link>

--- a/src/components/sidebar/card-list.tsx
+++ b/src/components/sidebar/card-list.tsx
@@ -13,7 +13,7 @@ interface CardListProps {
 export default function CardList({ data, showMore, className }: CardListProps) {
   return (
     <ul className={className}>
-      {data.map((parsed) => (
+      {data?.map((parsed) => (
         <li key={parsed.id} className="mb-4">
           <SidebarDatasetCard {...parsed}>
             {parsed.type === 'monitor' && <DatasetCardMonitor showMore={showMore} {...parsed} />}

--- a/src/components/sidebar/card-monitor-content.tsx
+++ b/src/components/sidebar/card-monitor-content.tsx
@@ -23,6 +23,8 @@ function DatasetCardMonitor({ showMore, theme, title, geostories, color, id, mon
                   href={`/explore/geostory/${geostory.id}${
                     geostory.geostory_bbox ? `?bbox=${geostory.geostory_bbox.join(',')}` : ''
                   }`}
+                  className="font-bold underline decoration-gray-400 
+    hover:decoration-white-500 hover:decoration-2"
                 >
                   {geostory.title}
                 </Link>

--- a/src/components/sidebar/index.tsx
+++ b/src/components/sidebar/index.tsx
@@ -49,7 +49,7 @@ function MapSidebar() {
         </div>
         {/* Cards - Monitors & Geostories */}
         {isLoading && !isFetched && <Loading />}
-        {!isLoading && isFetched && <CardList data={results} showMore={showDetail} />}
+        {!isLoading && isFetched && results && <CardList data={results} showMore={showDetail} />}
       </SidebarContent>
     </>
   );

--- a/src/components/timeseries/index.tsx
+++ b/src/components/timeseries/index.tsx
@@ -31,7 +31,7 @@ const TimeSeries: FC<{
   isActive: boolean;
   defaultActive?: boolean;
   autoPlay: boolean;
-}> = ({ range, isActive, layerId, defaultActive = 'false', autoPlay }) => {
+}> = ({ range, isActive, layerId, defaultActive = false, autoPlay }) => {
   const [layers, setLayers] = useSyncLayersSettings();
   const [compareLayers, setCompareLayers] = useSyncCompareLayersSettings();
   const [isPlaying, setPlaying] = useState(autoPlay && defaultActive && isActive);
@@ -221,7 +221,7 @@ const TimeSeries: FC<{
                   <div key={r.value} className="flex w-full items-center justify-center">
                     <div
                       className={cn('h-[6px] w-[1px] bg-white-800', {
-                        'bg-accent-green': r.value === compareDate,
+                        'w-[1.5px] bg-accent-green': r.value === currentRange?.value,
                       })}
                     />
                   </div>

--- a/src/components/web-traffic/map.tsx
+++ b/src/components/web-traffic/map.tsx
@@ -1,12 +1,14 @@
 import Script from 'next/script';
 
 const WebTrafficMapContent = () => (
-  <div style={{ width: '100%', height: '400px', position: 'relative' }}>
-    <Script
-      id="clustrmaps"
-      src="//cdn.clustrmaps.com/map_v2.js?cl=ffffff&w=a&t=tt&d=e9bF-yBRaYPXvvGpxTgq-74ob4nqMoaLjIgTO-UoDyQ&co=092539"
-      strategy="afterInteractive"
-    />
+  <div className="max-h-[600px] min-h-[300px] w-full">
+    <div style={{ width: '100%', height: '400px', position: 'relative' }}>
+      <Script
+        id="clustrmaps"
+        src="//cdn.clustrmaps.com/map_v2.js?cl=ffffff&w=a&t=tt&d=e9bF-yBRaYPXvvGpxTgq-74ob4nqMoaLjIgTO-UoDyQ&co=092539"
+        strategy="afterInteractive"
+      />
+    </div>
   </div>
 );
 

--- a/src/containers/explore/toolbar/mobile/nav-bar/index.tsx
+++ b/src/containers/explore/toolbar/mobile/nav-bar/index.tsx
@@ -99,7 +99,7 @@ const MobileExploreNavbar = () => {
             </header>
             <ScrollArea className="h-full">
               {isLoading && !isFetched && <Loading />}
-              {!isLoading && isFetched && (
+              {!isLoading && isFetched && results && (
                 <CardList className="px-6" data={results} showMore={showDetail} />
               )}
             </ScrollArea>

--- a/src/containers/sidebar/back-monitors-geostories-button.tsx
+++ b/src/containers/sidebar/back-monitors-geostories-button.tsx
@@ -12,7 +12,7 @@ import { buttonVariants } from '@/components/ui/button';
 
 const BackToMonitorsAndGeostories: FC = () => {
   return (
-    <Link href="/explore" className="flex items-center gap-2">
+    <Link href="/explore" className="z-10 flex items-center gap-2 pb-4">
       <div className={cn(buttonVariants({ variant: 'background' }), 'rounded-full p-2.5')}>
         <ArrowLeft className="h-6 w-6" />
       </div>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -286,3 +286,26 @@
     transform: translateX(100%);
   }
 }
+
+¡#clustrmaps-widget-v2 {
+  display: block;
+  width: 100% !important;
+  max-width: 1200px;
+  margin: 0 auto;
+  aspect-ratio: 16 / 9;
+  height: auto !important;
+  background: transparent;
+}
+
+#clustrmaps-widget-v2 .clustrmaps-map,
+#clustrmaps-widget-v2 .jvectormap-container,
+#clustrmaps-widget-v2 svg {
+  width: 100% !important;
+  height: 100% !important;
+}
+
+@media (max-width: 640px) {
+  #clustrmaps-widget-v2 {
+    aspect-ratio: 3 / 4;
+  }
+}


### PR DESCRIPTION
This pull request introduces a new Monitor details page and refactors related components for improved modularity, consistency, and UI/UX. The main changes include creating dedicated components for monitor pages, updating sidebar and card behaviors, and improving the handling and display of time series and web traffic maps.

**Monitor Page Implementation and Refactor:**

- Added a new `MonitorPageComponent` (`src/components/monitors/page/index.tsx`) to serve as the main component for monitor detail pages, including logic for fetching monitor data, layers, and initializing state. The existing route now uses this component instead of the dataset map component. ([src/components/monitors/page/index.tsxR1-R93](diffhunk://#diff-da13e671b0c162e97a9ad4f92932d34a94fb8f8518d7b3d76fda2155758654c4R1-R93), [src/app/explore/monitor/[monitor_id]/page.tsxL7-R7](diffhunk://#diff-0f9466bd69d1501623f5fe27deaa2f808099c8e72f86366f0ed36a9b71c895c6L7-R7), [src/app/explore/monitor/[monitor_id]/page.tsxL32-R32](diffhunk://#diff-0f9466bd69d1501623f5fe27deaa2f808099c8e72f86366f0ed36a9b71c895c6L32-R32))
- Implemented `MonitorView` (`src/components/monitors/view/index.tsx`) to display monitor details, associated datasets, and handle empty states.

**Sidebar and Card UI/UX Improvements:**

- Updated the sidebar for both monitor and geostory pages to use `ScrollArea`, sticky headers, and consistent card headers. The monitor and geostory sidebars now display a sticky back button and card header at the top. [[1]](diffhunk://#diff-4a5f10475ba3e812766c8637c7d72291862329d85fa3f8428d9288c91a368c37L14-R15) [[2]](diffhunk://#diff-4a5f10475ba3e812766c8637c7d72291862329d85fa3f8428d9288c91a368c37L55-R69) [[3]](diffhunk://#diff-da13e671b0c162e97a9ad4f92932d34a94fb8f8518d7b3d76fda2155758654c4R1-R93)
- Improved the `CardHeader` component with a hover underline animation for titles.
- Enhanced geostory links in monitor cards with underline and hover styles for better visibility.
- Ensured `CardList` and related sidebar components handle empty or undefined data gracefully. [[1]](diffhunk://#diff-3c6fdd6b2404db49deb39379195b457b8a9c48410797da5ee4020b50eb39bc25L16-R16) [[2]](diffhunk://#diff-750bc162bda45bcaf655eda358f5e5c88fadabf32346378055adcb9340e90d2bL52-R52) [[3]](diffhunk://#diff-50f7ada0232718b22a2d40323af998b531812c709ed7047c6b0ae98ec295d4a5L102-R102)

**Time Series and Dataset Card Behavior:**

- Modified `TimeSeries` component defaults to always autoplay and be active when displayed, and fixed the default value for `defaultActive` to be boolean. [[1]](diffhunk://#diff-4ba584025b4a72bf6c93cba379a0b7bccd21293da3d8d98f2e6c01a0070cca5bR129-R136) [[2]](diffhunk://#diff-275d5057d67e728fd045172e3ce228432032e0cbe512d5387c90179a3e21e7c2L34-R34)
- Updated the time series timeline indicator to highlight the current range instead of the comparison date.

**Web Traffic Map and Global Styles:**

- Wrapped the web traffic map in a responsive container and added global CSS for the Clustrmaps widget, including aspect ratio adjustments for mobile devices. [[1]](diffhunk://#diff-63a813b95346be95e2b25e54bbea3817f0472d5e8d9b626d6b8d06a5415afc62R4-R12) [[2]](diffhunk://#diff-dd438e7ca4da8a47a35709920a07b6fef918609c1daa40f6e9b794ddfd3e4996R289-R311)

**Minor UI Tweaks:**

- Adjusted the back button to have better spacing and layering.
- Set a minimum width for map tooltips to improve readability.
- Removed redundant card header in `GeostoriesView` now that it's handled in the sidebar.

These changes collectively improve the modularity, maintainability, and user experience of monitor and geostory exploration pages.