### PR TITLE
cleaning

### DIFF
--- a/src/components/datasets/card/index.tsx
+++ b/src/components/datasets/card/index.tsx
@@ -4,7 +4,7 @@ import { FC, useCallback, useMemo } from 'react';
 
 import Image from 'next/image';
 
-import { useAtom, useAtomValue } from 'jotai';
+import { useAtom } from 'jotai';
 import { HiOutlineExternalLink } from 'react-icons/hi';
 import { LuLayers2 } from 'react-icons/lu';
 

--- a/src/components/map/legend/types/choropleth/index.tsx
+++ b/src/components/map/legend/types/choropleth/index.tsx
@@ -25,7 +25,7 @@ export const LegendTypeChoropleth: React.FC<{
 
           {/* First column */}
           <div className="flex flex-col space-y-1">
-            {entries.slice(0, Math.ceil(entries.length / 2)).map((entry, i) => (
+            {entries.slice(0, Math.ceil(entries.length / 2)).map((entry) => (
               <div
                 key={`col1-${entry?.label}`}
                 className="flex items-baseline space-x-2"
@@ -39,7 +39,7 @@ export const LegendTypeChoropleth: React.FC<{
 
           {/* Second column */}
           <div className="flex flex-col space-y-1">
-            {entries.slice(Math.ceil(entries.length / 2)).map((entry, i) => (
+            {entries.slice(Math.ceil(entries.length / 2)).map((entry) => (
               <div
                 key={`col2-${entry?.label}`}
                 className="flex items-baseline space-x-2"

--- a/src/components/map/stats/point-histogram.tsx
+++ b/src/components/map/stats/point-histogram.tsx
@@ -4,7 +4,6 @@ import { FC, useCallback, useMemo } from 'react';
 
 import { format } from 'd3-format';
 import { useAtomValue } from 'jotai';
-import { h } from 'next-usequerystate/dist/parsers-fd455cd5';
 import { FiDownload } from 'react-icons/fi';
 
 import { cn } from '@/lib/classnames';

--- a/src/components/map/tooltip/geostory-tooltip.tsx
+++ b/src/components/map/tooltip/geostory-tooltip.tsx
@@ -4,11 +4,8 @@ import React, { FC, useMemo, useCallback } from 'react';
 
 import { format } from 'd3-format';
 import { useAtom, useSetAtom } from 'jotai';
-import { XIcon } from 'lucide-react';
 import { Coordinate } from 'ol/coordinate';
 import TileWMS from 'ol/source/TileWMS';
-
-import cn from '@/lib/classnames';
 
 import {
   coordinateAtom,
@@ -32,7 +29,6 @@ interface TooltipProps extends GeostoryTooltipInfo {
 
 const GeostoryTooltip: FC<TooltipProps> = ({
   position,
-  onCloseTooltip = () => null,
   leftData,
   rightData,
   nutsProperties,
@@ -42,7 +38,7 @@ const GeostoryTooltip: FC<TooltipProps> = ({
   const setNutsDataParams = useSetAtom(nutsDataParamsAtom);
 
   const [isRegionsLayerActive] = useAtom(regionsLayerVisibilityAtom);
-  const [isHistogramActive, isHistogramVisibility] = useAtom(histogramVisibilityAtom);
+  const isHistogramVisibility = useSetAtom(histogramVisibilityAtom);
 
   const handleClick = () => {
     isHistogramVisibility(true);

--- a/src/components/web-traffic/map.tsx
+++ b/src/components/web-traffic/map.tsx
@@ -1,14 +1,17 @@
 import Script from 'next/script';
 
 const WebTrafficMapContent = () => (
-  <div className="max-h-[600px] min-h-[300px] w-full">
-    <div style={{ width: '100%', height: '400px', position: 'relative' }}>
-      <Script
-        id="clustrmaps"
-        src="//cdn.clustrmaps.com/map_v2.js?cl=ffffff&w=a&t=tt&d=e9bF-yBRaYPXvvGpxTgq-74ob4nqMoaLjIgTO-UoDyQ&co=092539"
-        strategy="afterInteractive"
-      />
-    </div>
+  <div style={{ width: '100%', height: '400px', position: 'relative' }}>
+    {/* <script
+      type="text/javascript"
+      id="clustrmaps"
+      src="//cdn.clustrmaps.com/map_v2.js?cl=ffffff&w=a&t=tt&d=e9bF-yBRaYPXvvGpxTgq-74ob4nqMoaLjIgTO-UoDyQ&co=092539"
+    /> */}
+
+    <Script
+      id="clustrmaps"
+      src="//cdn.clustrmaps.com/map_v2.js?cl=ffffff&w=a&t=tt&d=e9bF-yBRaYPXvvGpxTgq-74ob4nqMoaLjIgTO-UoDyQ&co=092539"
+    />
   </div>
 );
 

--- a/src/hooks/monitors.ts
+++ b/src/hooks/monitors.ts
@@ -1,6 +1,5 @@
 import { useQuery, UseQueryOptions } from '@tanstack/react-query';
 import { AxiosError, AxiosResponse } from 'axios';
-import compact from 'lodash/compact';
 
 import type { Geostory } from '@/types/geostories';
 import type { Layer, LayerParsed } from '@/types/layers';

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -269,15 +269,6 @@
   background-color: hsl(60, 100%, 95%);
 }
 
-#clustrmaps-widget-v2 {
-  position: absolute !important;
-  top: 392px !important;
-  left: 0 !important;
-  right: 0 !important;
-  width: 100%;
-  height: 500px !important;
-}
-
 @keyframes shimmer {
   0% {
     transform: translateX(-100%);


### PR DESCRIPTION
This pull request includes a series of small cleanup and refactoring changes across several components, primarily focused on removing unused imports, simplifying code, and improving clarity. There are also minor adjustments to the web traffic map component and related CSS.

**Code cleanup and refactoring:**

* Removed unused imports from several files, including `lucide-react`, `lodash/compact`, and others, to keep the codebase clean and free of unnecessary dependencies. [[1]](diffhunk://#diff-ad544a5e0f84c48a78e8c31e413332ca4dfffd224514723f63a0b1a56f3aabb6L7-L12) [[2]](diffhunk://#diff-1d6b54b56cb92067f46858ab65fd0b8a6799964c1129e49f900e19879becc1bbL3) [[3]](diffhunk://#diff-dd718d4bec399f99661cee43b6f31b842dd554c26bf6d4370f6f59dddfd04933L7)
* Simplified map legend rendering by removing the unused index parameter from the `.map` callbacks in `LegendTypeChoropleth`. [[1]](diffhunk://#diff-6266647b57b4fb690c6fffbb9af24c1feaa0273b73d69c9faf6cd31f569a096eL28-R28) [[2]](diffhunk://#diff-6266647b57b4fb690c6fffbb9af24c1feaa0273b73d69c9faf6cd31f569a096eL42-R42)
* Cleaned up the `GeostoryTooltip` component by removing the default `onCloseTooltip` prop and correcting the use of the `histogramVisibilityAtom`. [[1]](diffhunk://#diff-ad544a5e0f84c48a78e8c31e413332ca4dfffd224514723f63a0b1a56f3aabb6L35) [[2]](diffhunk://#diff-ad544a5e0f84c48a78e8c31e413332ca4dfffd224514723f63a0b1a56f3aabb6L45-R41)
* Updated imports in `datasets/card/index.tsx` to remove the unused `useAtomValue`.

**Web traffic map adjustments:**

* Updated the structure and styling of the `WebTrafficMapContent` component, including removing an unnecessary wrapper div, commenting out an inline script, and cleaning up the usage of the `Script` component.
* Removed custom CSS targeting `#clustrmaps-widget-v2` from `globals.css` to avoid unnecessary or conflicting styles.

