### PR TITLE
Fix/stats map

### DIFF
--- a/e2e/datasets-hub.spec.ts
+++ b/e2e/datasets-hub.spec.ts
@@ -91,7 +91,7 @@ test.describe('monitors and geostories display', () => {
     await geostoriesCheckbox.click();
 
     const geostoriesResponse = await page.waitForResponse(
-      `${process.env.NEXT_PUBLIC_API_URL}/monitors-and-geostories/?type=geostories*`
+      `${process.env.NEXT_PUBLIC_API_URL}/monitors-and-geostories/*?type=geostories*`
     );
 
     const geostoriesData = (await geostoriesResponse.json()) as MonitorsAndGeostoriesPaginated;


### PR DESCRIPTION
This pull request introduces improvements to the web traffic statistics section and refactors layout handling for better client-side rendering and conditional display of the footer. The most significant changes include moving the footer rendering logic into a new client-side layout component, updating the web traffic map to use a script-based embed, and enhancing the presentation of web traffic rankings.

**Layout and Footer Refactor:**
* Created a new `LayoutClient` component in `src/app/layout-client.tsx` to handle client-side rendering and conditional display of the `Footer`—the footer is now only shown when the pathname is not `/explore`.
* Updated `src/app/layout.tsx` to wrap children with `LayoutClient` inside the main layout, ensuring consistent footer behavior across pages [[1]](diffhunk://#diff-29d0a55f5ca1a9951042587f8b891bb4cd8b204f5bc855dc2468ed44cde2f5b3L5-R12) [[2]](diffhunk://#diff-29d0a55f5ca1a9951042587f8b891bb4cd8b204f5bc855dc2468ed44cde2f5b3L61-R65).
* Removed the direct rendering of `Footer` from the homepage (`src/app/page.tsx`), delegating its display to the new layout logic.

**Web Traffic Statistics Section:**
* Replaced the custom `WebTrafficMapContent` with a direct `<Script>` embed of ClustrMaps in `src/components/web-traffic/content.tsx`, simplifying map integration and removing unused code.
* Updated the ranking list UI in `src/components/web-traffic/list.tsx` to use larger headings and more spacing for a clearer presentation.
* Added a CSS rule for `#clustrmaps` to ensure proper display and positioning of the embedded map (src/styles/globals.css).

**Other UI and Test Adjustments:**
* Commented out the sidebar trigger in the desktop explore toolbar for a cleaner interface (`src/containers/explore/toolbar/desktop/index.tsx`).
* Improved the usage stats page layout and ensured minimum height for better consistency (`src/app/usage-stats/page.tsx`) [[1]](diffhunk://#diff-9659fb654f5a9e10ca9b94b5fcd533e72bd6e32db0f7e5443eb0e1b8b028da5cR3-R10) [[2]](diffhunk://#diff-9659fb654f5a9e10ca9b94b5fcd533e72bd6e32db0f7e5443eb0e1b8b028da5cR21).

**Testing:**
* Corrected the API URL pattern in the E2E test for geostories filtering to match the new endpoint structure (`e2e/datasets-hub.spec.ts`).

