### PR TITLE
autoplay

### DIFF
--- a/src/components/timeseries/index.tsx
+++ b/src/components/timeseries/index.tsx
@@ -42,7 +42,7 @@ const TimeSeries: FC<{
 
   useEffect(() => {
     sessionStorage.setItem(STORAGE_KEY(layerId), JSON.stringify(isPlaying));
-  }, [isPlaying, layerId]);
+  }, []);
 
   const opacity = layers?.[0]?.opacity;
   const [contentVisibility, setContentVisibility] = useState<boolean>(false);
@@ -191,6 +191,8 @@ const TimeSeries: FC<{
         isActive={isActive}
         defaultActive={defaultActive}
         autoPlay={autoPlay}
+        isPlaying={isPlaying}
+        setPlaying={setPlaying}
       />
     </div>
   );

--- a/src/components/timeseries/timeline.tsx
+++ b/src/components/timeseries/timeline.tsx
@@ -21,20 +21,11 @@ const Timeline: FC<{
   isActive: boolean;
   defaultActive?: boolean;
   autoPlay: boolean;
-}> = ({ range, isActive, layerId, defaultActive = false, autoPlay }) => {
+  isPlaying: boolean;
+  setPlaying: (value: boolean | ((prev: boolean) => boolean)) => void;
+}> = ({ range, isActive, layerId, isPlaying, setPlaying }) => {
   const [layers, setLayers] = useSyncLayersSettings();
   const [compareLayers] = useSyncCompareLayersSettings();
-  const initialAutoPlay = useRef(autoPlay && defaultActive && isActive);
-  const STORAGE_KEY = (id: string) => `timeseries:${id}:playing`;
-
-  const [isPlaying, setPlaying] = useState<boolean>(() => {
-    const saved = sessionStorage.getItem(STORAGE_KEY(layerId));
-    return saved !== null ? JSON.parse(saved) : !!initialAutoPlay.current;
-  });
-
-  useEffect(() => {
-    sessionStorage.setItem(STORAGE_KEY(layerId), JSON.stringify(isPlaying));
-  }, [isPlaying, layerId]);
 
   const handleTogglePlay = useCallback(() => {
     void setPlaying((prev) => !prev);


### PR DESCRIPTION


This pull request refactors the playback state management for the time series timeline component. The main change is lifting the `isPlaying` state and its setter from the `Timeline` component to its parent, `TimeSeries`, and passing them down as props. This simplifies state management and improves consistency. Additionally, session storage logic for playback state has been removed from `Timeline`.

**State management refactor:**

* Lifted `isPlaying` state and `setPlaying` function from `Timeline` to `TimeSeries`, passing them as props to `Timeline` instead of managing them locally. (`src/components/timeseries/timeline.tsx`, [[1]](diffhunk://#diff-f2d9bb930f9d09949a7ea995c1db3e608415d9b35dd03012d6e9b3b025ebd68bL24-L37); `src/components/timeseries/index.tsx`, [[2]](diffhunk://#diff-275d5057d67e728fd045172e3ce228432032e0cbe512d5387c90179a3e21e7c2R194-R195)

**Session storage logic update:**

* Removed session storage logic for playback state from the `Timeline` component, centralizing it in the parent `TimeSeries` component. (`src/components/timeseries/timeline.tsx`, [[1]](diffhunk://#diff-f2d9bb930f9d09949a7ea995c1db3e608415d9b35dd03012d6e9b3b025ebd68bL24-L37); `src/components/timeseries/index.tsx`, [[2]](diffhunk://#diff-275d5057d67e728fd045172e3ce228432032e0cbe512d5387c90179a3e21e7c2L45-R45)