### PR TITLE
autoplay

### DIFF
--- a/src/components/main-menu/nav-links.tsx
+++ b/src/components/main-menu/nav-links.tsx
@@ -18,11 +18,10 @@ const NavLinks = () => {
           <li
             key={props.href}
             className={cn({
-              'decoration px-5 py-4 hover:bg-white-100': true,
-              'list-inside list-disc': isActive,
+              'decoration px-5 py-4 hover:bg-accent-green': true,
             })}
           >
-            <Link {...props} className="space-x-2.5">
+            <Link {...props} className="flex items-center space-x-2.5">
               <span>{name}</span>
             </Link>
           </li>

--- a/src/components/social-media/index.tsx
+++ b/src/components/social-media/index.tsx
@@ -27,7 +27,7 @@ const SocialMediaFeed = () => {
   const isMobile = useMediaQuery(mobile);
   const isTablet = useMediaQuery(tablet);
   return (
-    <section className="container relative h-[calc(100vh-240px)] w-screen font-satoshi sm:h-min sm:max-w-none">
+    <section className="sm_pb-20 container relative h-[calc(100vh-240px)] w-screen pb-0 font-satoshi sm:h-min sm:max-w-none">
       <div className="pointer-events-none absolute inset-0 -z-10 bg-[url(/images/landing/bg_social_media.svg)] bg-cover bg-center" />
       <div className="col-span-12 m-auto flex flex-col items-center justify-center space-y-[18px] sm:space-y-10">
         <h3 className="max-w-md py-6 text-center font-medium sm:text-2xl md:max-w-xl md:pb-12 md:pt-20 lg:max-w-3xl lg:py-28 lg:text-[28px]">

--- a/src/components/timeseries/index.tsx
+++ b/src/components/timeseries/index.tsx
@@ -32,17 +32,35 @@ const TimeSeries: FC<{
   const [layers, setLayers] = useSyncLayersSettings();
   const [compareLayers, setCompareLayers] = useSyncCompareLayersSettings();
 
-  const initialAutoPlay = useRef(autoPlay && defaultActive && isActive);
-  const STORAGE_KEY = (id: string) => `timeseries:${id}:playing`;
+  const keyFor = (id: string) => `timeseries:${id}:playing`;
 
-  const [isPlaying, setPlaying] = useState<boolean>(() => {
-    const saved = sessionStorage.getItem(STORAGE_KEY(layerId));
-    return saved !== null ? JSON.parse(saved) : !!initialAutoPlay.current;
-  });
+  const initRef = useRef(false);
+
+  const [isPlaying, setPlaying] = useState<boolean>(false);
+  useEffect(() => {
+    if (!layerId || initRef.current) return;
+
+    const key = keyFor(layerId);
+    let initial = false;
+
+    const saved = sessionStorage.getItem(key);
+    if (saved !== null) {
+      try {
+        initial = JSON.parse(saved);
+      } catch {}
+    } else {
+      initial = !!(autoPlay && defaultActive && isActive);
+    }
+
+    setPlaying(initial);
+    initRef.current = true;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [layerId]);
 
   useEffect(() => {
-    sessionStorage.setItem(STORAGE_KEY(layerId), JSON.stringify(isPlaying));
-  }, []);
+    if (!layerId) return;
+    sessionStorage.setItem(keyFor(layerId), JSON.stringify(isPlaying));
+  }, [layerId, isPlaying]);
 
   const opacity = layers?.[0]?.opacity;
   const [contentVisibility, setContentVisibility] = useState<boolean>(false);

--- a/src/components/timeseries/timeline.tsx
+++ b/src/components/timeseries/timeline.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useCallback, useState, useRef } from 'react';
+import { useMemo, useCallback } from 'react';
 import type { FC } from 'react';
 
 import { TooltipPortal } from '@radix-ui/react-tooltip';


### PR DESCRIPTION
This pull request includes improvements to state management and code clarity in the `TimeSeries` component, as well as minor updates to the `SocialMediaFeed` and `Timeline` components. The most significant changes involve refactoring the logic for initializing and persisting the playback state in `TimeSeries`, leading to more reliable behavior and cleaner code.

**State management and logic improvements:**

* Refactored the initialization of the `isPlaying` state in `TimeSeries` to use an effect that reads from `sessionStorage` only after `layerId` is available, ensuring correct initial playback state and avoiding stale values.
* Updated the effect that persists the `isPlaying` state to `sessionStorage` to run whenever `layerId` or `isPlaying` changes, improving reliability and consistency of state persistence.

**Code clarity and minor updates:**

* Simplified the import statements in `timeline.tsx` by removing unused React hooks, reducing unnecessary code.
* Added a `sm_pb-20` class to the `SocialMediaFeed` section to adjust padding for better mobile layout.