### PR TITLE
fix: timeline controls, histogram error handling, legend overflow

### DIFF
--- a/src/components/datasets/card/index.tsx
+++ b/src/components/datasets/card/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { FC, useCallback, useMemo } from 'react';
+import { FC, useCallback, useEffect, useMemo, useRef } from 'react';
 
 import { useAtom } from 'jotai';
 
@@ -42,7 +42,7 @@ const DatasetCard: FC<DatasetCardProps> = ({
   const isCompareActive = useMemo(() => compareLayers?.[1]?.id === id, [id, compareLayers]);
 
   const [isHistogramActive] = useAtom(histogramVisibilityAtom);
-  // isActive is based on the url
+  const cardRef = useRef<HTMLDivElement>(null);
 
   const layerToCompareId = useMemo(() => {
     if (!comparisonLayer) return null;
@@ -85,8 +85,17 @@ const DatasetCard: FC<DatasetCardProps> = ({
     compareLayers,
   ]);
 
+  useEffect(() => {
+    if (!isHistogramActive || !isActive || !cardRef.current) return;
+    requestAnimationFrame(() => {
+      cardRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    });
+  }, [isHistogramActive, isActive]);
+
   return (
     <div
+      ref={cardRef}
+      id={`histogram-anchor-${id}`}
       className="space-y-3 rounded-3xl border border-black-100 p-3.5 text-sm font-medium text-white-50"
       data-testid={`dataset-item-${id}`}
     >

--- a/src/components/geostories/view/index.tsx
+++ b/src/components/geostories/view/index.tsx
@@ -30,10 +30,8 @@ const GeostoriesView: FC<GeostoriesViewProps> = ({ data, geostoryLayers, compari
     setStatus((prevStatus) => (prevStatus === 'open' ? 'closed' : 'open'));
   };
 
-  console.log(monitors);
-
   return (
-    <>
+    <div className="space-y-6 py-3">
       <div className="relative space-y-6 py-3">
         <p className="text-sm font-medium text-white-50" data-testid="geostory-description">
           {description}
@@ -85,7 +83,7 @@ const GeostoriesView: FC<GeostoriesViewProps> = ({ data, geostoryLayers, compari
           onOpenChange={(open) => setMonitorStatus(open ? 'open' : 'closed')}
         >
           <div className="flex w-full items-center justify-between">
-            <h2 className="py-2 font-medium">Monitors</h2>
+            <h2 className="font-medium">Monitors</h2>
             <CollapsibleTrigger
               className="w-fit p-0 data-[state=open]:bg-transparent"
               data-testid="collapse-monitors-button"
@@ -111,7 +109,7 @@ const GeostoriesView: FC<GeostoriesViewProps> = ({ data, geostoryLayers, compari
           </CollapsibleContent>
         </Collapsible>
       )}
-    </>
+    </div>
   );
 };
 

--- a/src/components/line-chart/index.tsx
+++ b/src/components/line-chart/index.tsx
@@ -35,8 +35,14 @@ export const LineChart = ({
   color,
   compareColor,
 }: {
-  data: { title?: string; data: { x: string | number | Date; y: number; unit: string }[] };
-  dataCompare?: { title?: string; data: { x: string | number | Date; y: number; unit: string }[] };
+  data: {
+    title?: string;
+    data: { x: string | number | Date; y: number | null; unit?: string }[];
+  };
+  dataCompare?: {
+    title?: string;
+    data: { x: string | number | Date; y: number | null; unit?: string }[];
+  };
   color: string;
   compareColor?: string;
 }) => {
@@ -44,6 +50,15 @@ export const LineChart = ({
     scroll: true,
     detectBounds: true,
   });
+  const validData = useMemo(
+    () => data?.data?.filter((d) => d.y != null && Number.isFinite(d.y)) ?? [],
+    [data]
+  );
+  const validCompareData = useMemo(
+    () => dataCompare?.data?.filter((d) => d.y != null && Number.isFinite(d.y)) ?? [],
+    [dataCompare]
+  );
+
   const theme = buildChartTheme({
     backgroundColor: 'transparent',
     gridColor: '#9CA3AF',
@@ -51,7 +66,7 @@ export const LineChart = ({
     colors: [color, '#ffffe6'],
     tickLength: 5,
   });
-  const xSample = data?.data?.[0]?.x;
+  const xSample = validData[0]?.x;
   const isDate = !isNaN(Date.parse(String(xSample)));
   const isNumber = typeof xSample === 'number';
 
@@ -64,14 +79,14 @@ export const LineChart = ({
 
   const allY = useMemo(
     () => [
-      ...data.data.map(accessors.yAccessor),
-      ...(dataCompare?.data ?? []).map(accessors.yAccessor),
+      ...validData.map(accessors.yAccessor),
+      ...validCompareData.map(accessors.yAccessor),
     ],
-    [data, dataCompare, accessors.yAccessor]
+    [validData, validCompareData, accessors.yAccessor]
   );
-  const yMin = useMemo(() => Math.min(...allY), [allY]);
-  const yMax = useMemo(() => Math.max(...allY), [allY]);
-  const unit = data.data[0]?.unit || '';
+  const yMin = useMemo(() => (allY.length ? Math.min(...allY) : 0), [allY]);
+  const yMax = useMemo(() => (allY.length ? Math.max(...allY) : 0), [allY]);
+  const unit = validData[0]?.unit || '';
   return (
     <div ref={containerRef} className="relative h-72 w-full text-white-500">
       <ParentSize>
@@ -118,15 +133,15 @@ export const LineChart = ({
 
             <AnimatedLineSeries
               dataKey={data?.title}
-              data={data.data}
+              data={validData}
               xAccessor={accessors.xAccessor}
               yAccessor={accessors.yAccessor}
               colorAccessor={() => color}
             />
-            {dataCompare && (
+            {dataCompare && validCompareData.length > 0 && (
               <AnimatedLineSeries
                 dataKey={dataCompare.title}
-                data={dataCompare.data}
+                data={validCompareData}
                 xAccessor={accessors.xAccessor}
                 yAccessor={accessors.yAccessor}
                 colorAccessor={() => compareColor || '#ffffe6'}

--- a/src/components/map/index.tsx
+++ b/src/components/map/index.tsx
@@ -56,10 +56,9 @@ import {
 } from './constants';
 // map controls
 import Controls from './controls';
+import NutsLayer from './layers/nuts';
 import Legend from './legend';
 import MapTooltip from './tooltip';
-import { Nut } from 'lucide-react';
-import NutsLayer from './layers/nuts';
 
 function buildWmsSource(url: string, layerName: string) {
   return new TileWMS({
@@ -403,6 +402,7 @@ const Map: FC<CustomMapProps> = ({ initialViewState = DEFAULT_VIEWPORT }) => {
     queryFn: ({ signal }) => fetchFeatureInfo(leftUrl, signal),
     enabled: Boolean(leftUrl && tooltipInfo.position),
     staleTime: 30_000,
+    keepPreviousData: true,
   });
 
   const qRight = useQuery({
@@ -416,6 +416,7 @@ const Map: FC<CustomMapProps> = ({ initialViewState = DEFAULT_VIEWPORT }) => {
     queryFn: ({ signal }) => fetchFeatureInfo(rightUrl, signal),
     enabled: Boolean(rightUrl && tooltipInfo.position),
     staleTime: 30_000,
+    keepPreviousData: true,
   });
 
   const qNuts = useQuery({
@@ -565,7 +566,11 @@ const Map: FC<CustomMapProps> = ({ initialViewState = DEFAULT_VIEWPORT }) => {
       {dataMeta && (
         <MapTooltip
           {...tooltipInfo}
-          data={tooltipSide === 'left' ? tooltipInfo.leftData : tooltipInfo.rightData}
+          data={
+            tooltipSide === 'right' && isCompareLayerActive
+              ? tooltipInfo.rightData
+              : tooltipInfo.leftData
+          }
           onCloseTooltip={handleCloseTooltip}
         />
       )}

--- a/src/components/map/legend/component.tsx
+++ b/src/components/map/legend/component.tsx
@@ -85,7 +85,7 @@ export const Legend: React.FC<{ children?: React.ReactNode }> = ({ children }) =
 
   return (
     <div
-      className="flex w-full flex-col space-y-4 rounded-b-sm border-gray-600 bg-brand-500 p-4"
+      className="flex w-full flex-col space-y-4 overflow-hidden rounded-b-sm border-gray-600 bg-brand-500 p-4"
       style={{ minWidth: legendWidth }}
     >
       <ScrollArea className={cn({ 'max-h-[216px]': !isLoadingLayerData })}>
@@ -107,7 +107,12 @@ export const Legend: React.FC<{ children?: React.ReactNode }> = ({ children }) =
               className="relative flex items-center justify-between space-x-4 text-secondary-500"
               data-testid="map-legend-item"
             >
-              <div data-testid="map-legend-item-title" className="text-xs font-bold" ref={titleRef}>
+              <div
+                data-testid="map-legend-item-title"
+                className="min-w-0 truncate text-xs font-bold"
+                ref={titleRef}
+                title={compareLayerData.title}
+              >
                 {compareLayerData.title}
               </div>
               <div

--- a/src/components/map/legend/index.tsx
+++ b/src/components/map/legend/index.tsx
@@ -67,7 +67,9 @@ export const Legend: React.FC<{
               className="relative flex flex-1 items-start justify-between space-x-4 text-white-500"
               data-testid="map-legend-item"
             >
-              <div data-testid="map-legend-item-title">{title}</div>
+              <div data-testid="map-legend-item-title" className="min-w-0 truncate" title={title}>
+                {title}
+              </div>
               <div
                 className="flex space-x-2 divide-x divide-secondary-800"
                 data-testid="map-legend-item-toolbar"

--- a/src/components/map/legend/timelime.tsx
+++ b/src/components/map/legend/timelime.tsx
@@ -63,7 +63,7 @@ export const LegendTimeseries: React.FC = () => {
   );
 
   return (
-    <div>
+    <div className="w-full overflow-hidden">
       {baseLayerData?.range && !!baseLayerData.range.length && (
         <TimeSeriesSameLayer
           layerId={mainLayer?.layer_id || ''}

--- a/src/components/map/stats/point-histogram.tsx
+++ b/src/components/map/stats/point-histogram.tsx
@@ -3,12 +3,12 @@
 import { FC, useCallback, useMemo } from 'react';
 
 import { format } from 'd3-format';
-import { useAtomValue } from 'jotai';
+import { useAtomValue, useSetAtom } from 'jotai';
 import { FiDownload } from 'react-icons/fi';
 
 import { cn } from '@/lib/classnames';
 
-import { lonLatAtom } from '@/app/store';
+import { histogramVisibilityAtom, lonLatAtom } from '@/app/store';
 
 import { downloadCSV } from '@/hooks/datasets';
 import { useLayerParsedSource } from '@/hooks/layers';
@@ -16,6 +16,7 @@ import { usePointData } from '@/hooks/map';
 
 import LineChart from '../../line-chart';
 import Loading from '../../loading';
+import { AnalysisSVG } from '@/SVGS/analysis';
 
 const numberFormat = format(',.2f');
 
@@ -28,6 +29,7 @@ type GeostoryTooltipInfo = {
 
 const PointHistogram: FC<GeostoryTooltipInfo> = ({ title, color, id }: GeostoryTooltipInfo) => {
   const lonLat = useAtomValue(lonLatAtom);
+  const setHistogramVisibility = useSetAtom(histogramVisibilityAtom);
 
   const { data } = useLayerParsedSource(
     {
@@ -83,9 +85,21 @@ const PointHistogram: FC<GeostoryTooltipInfo> = ({ title, color, id }: GeostoryT
     }
   }, [histogramData, histogramPointData, id, title]);
 
+  const handleCloseAnalysis = () => setHistogramVisibility(false);
+
   return (
     <div className="relative space-y-2">
-      <div className="space-y-4 font-satoshi">
+      <div className="space-y-3 font-satoshi font-bold">
+        <div className="flex w-full items-center justify-between gap-4">
+          <div className="flex items-center gap-1 text-white-500">
+            <AnalysisSVG className="h-6 w-6" />
+            <span>Analysis</span>
+          </div>
+
+          <button className="text-xs text-accent-green underline" onClick={handleCloseAnalysis}>
+            Close analysis
+          </button>
+        </div>
         <div className="flex items-center justify-between">
           <h4 className="font-medium" style={{ color }}>
             Location {numberFormat(lonLat[0])}, {numberFormat(lonLat[1])}

--- a/src/components/map/tooltip/geostory-tooltip.tsx
+++ b/src/components/map/tooltip/geostory-tooltip.tsx
@@ -68,6 +68,7 @@ const GeostoryTooltip: FC<TooltipProps> = ({
       crossOrigin: 'anonymous',
     });
   }, []);
+
   if (!position || !leftData?.value) return null;
 
   return (
@@ -96,18 +97,13 @@ const GeostoryTooltip: FC<TooltipProps> = ({
             )}
           </div>
           {leftData?.value && !isRegionsLayerActive && leftData.range && (
-            <Button
-              variant="default"
-              onClick={handleClick}
-              className="w-full p-2 font-inter text-xs"
-              disabled={!leftData.value}
-            >
-              See point-based summary
+            <Button variant="outline" onClick={handleClick} disabled={!leftData.value}>
+              Show point histogram
             </Button>
           )}
           {leftData?.value && isRegionsLayerActive && (
-            <Button variant="default" onClick={handleHistogram} className="p-2 font-inter text-xs">
-              See regions-based summary
+            <Button variant="outline" onClick={handleHistogram}>
+              Show region histogram
             </Button>
           )}
         </div>
@@ -123,24 +119,13 @@ const GeostoryTooltip: FC<TooltipProps> = ({
               </div>
             </div>
             {!isRegionsLayerActive && rightData.range && (
-              <Button
-                variant="default"
-                onClick={handleClick}
-                className="font-inter text-xs"
-                // disabled={true}
-              >
-                See point-based summary
+              <Button variant="outline" onClick={handleClick}>
+                Show point histogram
               </Button>
             )}
             {!!isRegionsLayerActive && rightData.range && (
-              <Button
-                variant="default"
-                onClick={handleHistogram}
-                className="font-inter text-xs"
-                // disabled={!rightData.value}
-                // disabled={true}
-              >
-                See regions-based summary
+              <Button variant="outline" onClick={handleHistogram}>
+                Show region histogram
               </Button>
             )}
           </div>

--- a/src/components/map/tooltip/index.tsx
+++ b/src/components/map/tooltip/index.tsx
@@ -1,29 +1,26 @@
 'use client';
 
-import React, { FC, useCallback, useMemo } from 'react';
+import { FC, useCallback, useMemo } from 'react';
 
 import { format } from 'd3-format';
 import { useAtom, useSetAtom, useAtomValue } from 'jotai';
-import { Coordinate } from 'ol/coordinate';
-import { TileWMS } from 'ol/source';
-import { LuChartColumnBig, LuX } from 'react-icons/lu';
+import { LuX } from 'react-icons/lu';
 
-import cn from '@/lib/classnames';
-import { getHistogramData } from '@/lib/utils';
+import { useCountryName } from '@/hooks/countries';
+import { useLayer } from '@/hooks/layers';
 
 import {
-  coordinateAtom,
   histogramVisibilityAtom,
-  nutsDataParamsAtom,
   nutsDataResponseAtom,
   regionsLayerVisibilityAtom,
-  resolutionAtom,
 } from '@/app/store';
 
-import { useSyncSwipeControlPosition } from '@/hooks/sync-query';
+import { CATEGORIES_COLORS } from '@/constants/categories';
 
 import type { MonitorTooltipInfo } from '@/components/map/types';
 import { Button } from '@/components/ui/button';
+
+import { AnalysisSVG } from '@/SVGS/analysis';
 
 const numberFormat = format(',.2f');
 
@@ -51,38 +48,17 @@ type MapTooltipProps = Omit<TooltipProps, 'leftData' | 'rightData'> & {
 };
 
 const MapTooltip: FC<MapTooltipProps> = ({ position, onCloseTooltip = () => null, data }) => {
-  const [isHistogramActive, isHistogramVisibility] = useAtom(histogramVisibilityAtom);
+  const isHistogramVisibility = useSetAtom(histogramVisibilityAtom);
   const nutsDataResponse = useAtomValue(nutsDataResponseAtom);
-  const setNutsDataParams = useSetAtom(nutsDataParamsAtom);
-  const swipeSide = useSyncSwipeControlPosition();
+  const countryName = useCountryName(nutsDataResponse?.CNTR_CODE);
 
-  const [coordinate] = useAtom(coordinateAtom);
-  const [resolution] = useAtom(resolutionAtom);
+  const { data: layerData } = useLayer({
+    layer_id: data.id,
+  });
 
-  const wmsNutsSource = useMemo(() => {
-    return new TileWMS({
-      url: 'https://geoserver.earthmonitor.org/geoserver/oem/wms',
-      params: {
-        TILED: true,
-        ID: true,
-        name: 'oem:NUTS_RG_01M_2021_3035',
-        LAYERS: 'oem:NUTS_RG_01M_2021_3035',
-      },
-      serverType: 'geoserver',
-      crossOrigin: 'anonymous',
-    });
-  }, []);
-
-  const handleHistogram = useCallback(async () => {
-    const { nutsDataParams } = await getHistogramData(
-      wmsNutsSource,
-      coordinate as Coordinate,
-      resolution,
-      data?.id
-    );
-    setNutsDataParams(nutsDataParams);
+  const handleHistogram = useCallback(() => {
     isHistogramVisibility(true);
-  }, [coordinate, resolution, data?.id, isHistogramVisibility, setNutsDataParams, wmsNutsSource]);
+  }, [isHistogramVisibility]);
 
   const [isRegionsLayerActive] = useAtom(regionsLayerVisibilityAtom);
 
@@ -93,62 +69,66 @@ const MapTooltip: FC<MapTooltipProps> = ({ position, onCloseTooltip = () => null
     });
   }, [isHistogramVisibility, data?.id]);
 
+  const color = useMemo(() => {
+    return (
+      CATEGORIES_COLORS[layerData?.theme || 'Unknown'].base || CATEGORIES_COLORS['Unknown'].base
+    );
+  }, [layerData?.theme]);
+
   if (!position || (data?.value === undefined && data?.value !== 0)) return null;
+
+  const label = [nutsDataResponse?.NUTS_NAME, countryName].filter(Boolean).join(', ');
 
   return (
     <div
-      className={cn({
-        'absolute z-50 min-w-[250px] max-w-[300px] translate-x-[-50%] translate-y-[-100%] rounded-[20px] bg-white-500 p-5 font-satoshi font-medium text-black-500 shadow-md':
-          true,
-        hidden: isHistogramActive,
-      })}
+      className="absolute z-50 min-w-[250px] translate-x-[-50%] translate-y-[-100%] rounded-[20px] bg-black-150 p-5 font-satoshi font-medium text-white-500 shadow-md"
       style={{
         left: `${position[0]}px`,
         top: `${position[1] - 10}px`,
       }}
     >
       <div className="space-y-5">
-        <div className="flex w-full items-start justify-between">
-          <h3 className="break-word flex flex-wrap text-left">{data.title}</h3>
+        <div className="flex w-full items-start justify-between space-x-2">
+          <AnalysisSVG className="h-6 w-6 flex-shrink-0" />
+          <h3 style={{ color }} className="break-word flex max-w-[300px] flex-wrap  text-left ">
+            {data.title}
+          </h3>
 
           <button type="button" onClick={onCloseTooltip}>
             <LuX className="h-6 w-6" />
           </button>
         </div>
         {data.value !== 0 && (
-          <div className="flex flex-col items-start space-y-3">
-            {isRegionsLayerActive && !!nutsDataResponse?.NAME_LATN && (
-              <div className="flex flex-wrap space-x-2.5 divide-x-2 divide-white-900 text-left font-satoshi text-xs font-medium">
-                <span>{nutsDataResponse?.NAME_LATN}</span>
-                <span className="ml-2.5">{nutsDataResponse?.NUTS_NAME}</span>
-              </div>
-            )}
+          <>
+            <div className="flex items-center space-x-2 text-xs">
+              {isRegionsLayerActive && (
+                <span className="whitespace-nowrap">Location selected:</span>
+              )}
+              {isRegionsLayerActive && !!nutsDataResponse?.NUTS_NAME && (
+                <div className="flex space-x-2.5 whitespace-nowrap rounded-full bg-white-950 px-2 py-0.5 text-left font-satoshi font-medium">
+                  {label}
+                </div>
+              )}
+            </div>
             <div className="space-x-2 text-[22px]">
               {typeof data.value === 'number' ? (
                 <span>{numberFormat(data.value)}</span>
               ) : (
                 data.value
               )}
-              {!!data.unit && <span>{data.unit}</span>}
+              {!!data.unit && !!data.value && <span>{data.unit}</span>}
             </div>
-          </div>
+          </>
         )}
-        {!data.value && <span>No data is available at this specific point.</span>}
+        {!data.value && <span>No data is available at this specific location.</span>}
         {data?.value && !isRegionsLayerActive && (
-          <Button
-            variant="default"
-            onClick={handleClick}
-            className="space-x-2 p-2 text-sm"
-            disabled={!data.value}
-          >
-            <LuChartColumnBig className="h-6 w-6" />
-            <span>See point-based summary</span>
+          <Button variant="outline" onClick={handleClick} disabled={!data.value}>
+            Show point histogram
           </Button>
         )}
         {data?.value && isRegionsLayerActive && (
-          <Button variant="default" onClick={handleHistogram} className="space-x-2 p-2  text-sm">
-            <LuChartColumnBig className="h-6 w-6" />
-            <span> See regions-based summary</span>
+          <Button variant="outline" onClick={handleHistogram}>
+            Show region histogram
           </Button>
         )}
       </div>

--- a/src/components/map/tooltip/monitor-tooltip.tsx
+++ b/src/components/map/tooltip/monitor-tooltip.tsx
@@ -74,9 +74,11 @@ const MonitorTooltip: FC<TooltipProps> = ({
   };
 
   const dateLabel = leftData.range?.find(({ value }) => value === leftData.date)?.label;
+
   const compareDateLabel =
     rightData.date && leftData.range?.find(({ value }) => value === rightData.date)?.label;
   if (!position || (!leftData?.value && leftData?.value !== 0)) return null;
+
   return (
     <>
       <div className="relative space-y-4">
@@ -101,24 +103,14 @@ const MonitorTooltip: FC<TooltipProps> = ({
           </span>
         )}
         {!!leftData?.value && !isRegionsLayerActive && leftData.range && (
-          <Button
-            variant="default"
-            onClick={handleClick}
-            className="w-full font-inter text-xs"
-            disabled={!leftData.value}
-          >
-            See point-based summary
+          <Button variant="outline" onClick={handleClick} disabled={!leftData.value}>
+            Show point histogram
           </Button>
         )}
 
         {!!leftData?.value && isRegionsLayerActive && leftData.range && (
-          <Button
-            variant="default"
-            onClick={handleHistogram}
-            className="p-2 font-inter text-xs"
-            disabled={!leftData.value}
-          >
-            See regions-based summary
+          <Button variant="outline" onClick={handleHistogram} disabled={!leftData.value}>
+            Show region histogram
           </Button>
         )}
 

--- a/src/components/map/types.d.ts
+++ b/src/components/map/types.d.ts
@@ -110,5 +110,5 @@ export type NutsDataset = {
 };
 
 export type NuqsData = {
-  dataset: NutsDataset[];
+  dataset?: NutsDataset[];
 };

--- a/src/components/map/types.d.ts
+++ b/src/components/map/types.d.ts
@@ -103,10 +103,10 @@ export type NutsProperties = {
 };
 
 export type NutsDataset = {
-  avg: number;
+  avg: number | null;
   label: string;
-  max: number;
-  min: number;
+  max: number | null;
+  min: number | null;
 };
 
 export type NuqsData = {

--- a/src/components/timeseries-comparative-layers/index.tsx
+++ b/src/components/timeseries-comparative-layers/index.tsx
@@ -77,7 +77,7 @@ const TimeSeriesComparativeLayers: FC<{
       {/* Select dates */}
       <div className="flex flex-col space-y-2 text-secondary-500">
         <span className="text-sm">Select date:</span>
-        <div className="flex w-full items-center justify-between gap-6">
+        <div className="flex w-full items-center justify-between gap-4">
           {currentRange && (
             <Select
               value={currentRange.value}
@@ -85,12 +85,13 @@ const TimeSeriesComparativeLayers: FC<{
               open={contentVisibility}
               onOpenChange={setContentVisibility}
             >
-              <SelectTrigger className="w-fit text-xs font-semibold">
+              <SelectTrigger className="min-w-0 max-w-[50%] text-xs font-semibold">
                 <div
                   className={cn(
                     buttonVariants({ variant: 'outline', size: 'sm' }),
-                    'w-full justify-between hover:bg-transparent'
+                    'w-full justify-between overflow-hidden hover:bg-transparent'
                   )}
+                  title={currentRange?.label}
                 >
                   <SelectValue>{currentRange?.label}</SelectValue>
                   <SelectIcon />

--- a/src/components/timeseries-comparative-layers/timeline.tsx
+++ b/src/components/timeseries-comparative-layers/timeline.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useCallback } from 'react';
-import type { FC } from 'react';
+import type { FC, MouseEvent } from 'react';
 
 import { TooltipPortal } from '@radix-ui/react-tooltip';
 import { LuCirclePlay, LuCirclePause } from 'react-icons/lu';
@@ -28,9 +28,13 @@ const Timeline: FC<{
   const [layers, setLayers] = useSyncLayersSettings();
   const [compareLayers] = useSyncCompareLayersSettings();
 
-  const handleTogglePlay = useCallback(() => {
-    void setPlaying((prev) => !prev);
-  }, [isPlaying, setPlaying]);
+  const handleTogglePlay = useCallback(
+    (e: MouseEvent) => {
+      e.stopPropagation();
+      setPlaying((prev) => !prev);
+    },
+    [setPlaying]
+  );
 
   const date = layers?.[0]?.date;
 
@@ -58,7 +62,8 @@ const Timeline: FC<{
   );
 
   const handleTickClick = useCallback(
-    (value: string) => {
+    (e: MouseEvent, value: string) => {
+      e.stopPropagation();
       if (isCompareActive) return;
       void setLayers([{ ...layers?.[0], date: value }]);
     },
@@ -100,7 +105,7 @@ const Timeline: FC<{
                     className={cn('flex w-full items-center justify-center', {
                       'cursor-pointer': !isCompareActive,
                     })}
-                    onClick={() => handleTickClick(r.value)}
+                    onClick={(e) => handleTickClick(e, r.value)}
                   >
                     <div
                       className={cn('h-[6px] w-[1px] bg-white-800', {

--- a/src/components/timeseries-layer/index.tsx
+++ b/src/components/timeseries-layer/index.tsx
@@ -111,7 +111,7 @@ const TimeSeriesSameLayer: FC<{
       {/* Select dates */}
       <div className="flex flex-col space-y-2 text-secondary-500">
         <span className="text-sm">Select date:</span>
-        <div className="flex w-full items-center justify-between gap-6">
+        <div className="flex w-full items-center justify-between gap-4">
           {currentRange && range.length > 1 && (
             <Select
               value={currentRange.value}
@@ -119,12 +119,13 @@ const TimeSeriesSameLayer: FC<{
               open={contentVisibility}
               onOpenChange={setContentVisibility}
             >
-              <SelectTrigger className="w-fit text-xs font-semibold">
+              <SelectTrigger className="min-w-0 max-w-[50%] text-xs font-semibold">
                 <div
                   className={cn(
                     buttonVariants({ variant: 'outline', size: 'sm' }),
-                    'w-full justify-between hover:bg-transparent'
+                    'w-full justify-between overflow-hidden hover:bg-transparent'
                   )}
+                  title={currentRange?.label}
                 >
                   <SelectValue>{currentRange?.label}</SelectValue>
                   <SelectIcon />
@@ -147,12 +148,13 @@ const TimeSeriesSameLayer: FC<{
             </Select>
           )}
           {currentRange && range.length === 1 && (
-            <div className="w-fit text-xs font-semibold">
+            <div className="min-w-0 max-w-[50%] text-xs font-semibold">
               <div
                 className={cn(
                   buttonVariants({ variant: 'outline', size: 'sm' }),
-                  'w-full justify-between hover:bg-transparent'
+                  'w-full justify-between hover:bg-transparent truncate'
                 )}
+                title={currentRange?.label}
               >
                 {currentRange?.label}
               </div>
@@ -182,14 +184,17 @@ const TimeSeriesSameLayer: FC<{
                 setContentCompareVisibility((prev) => !prev);
               }}
             >
-              <SelectTrigger className="w-fit text-xs font-semibold ">
+              <SelectTrigger className="min-w-0 max-w-[50%] text-xs font-semibold">
                 <div
                   className={cn(
                     buttonVariants({ variant: 'outline', size: 'sm' }),
-                    'w-full justify-between hover:bg-transparent'
+                    'w-full justify-between overflow-hidden hover:bg-transparent'
                   )}
+                  title={compareCurrentRange?.label || range[0].label}
                 >
-                  <SelectValue>{compareCurrentRange?.label || range[0].label}</SelectValue>
+                  <SelectValue>
+                    {compareCurrentRange?.label || range[0].label}
+                  </SelectValue>
                   <div className="flex items-center space-x-2">
                     <LuX
                       className="pointer-events-auto h-4 w-4 text-accent-green"

--- a/src/components/timeseries-layer/timeline.tsx
+++ b/src/components/timeseries-layer/timeline.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useCallback } from 'react';
-import type { FC } from 'react';
+import type { FC, MouseEvent } from 'react';
 
 import { TooltipPortal } from '@radix-ui/react-tooltip';
 import { LuCirclePlay, LuCirclePause } from 'react-icons/lu';
@@ -28,9 +28,13 @@ const Timeline: FC<{
   const [layers, setLayers] = useSyncLayersSettings();
   const [compareLayers] = useSyncCompareLayersSettings();
 
-  const handleTogglePlay = useCallback(() => {
-    void setPlaying((prev) => !prev);
-  }, [isPlaying, setPlaying]);
+  const handleTogglePlay = useCallback(
+    (e: MouseEvent) => {
+      e.stopPropagation();
+      setPlaying((prev) => !prev);
+    },
+    [setPlaying]
+  );
 
   const date = layers?.[0]?.date;
 
@@ -58,7 +62,8 @@ const Timeline: FC<{
   );
 
   const handleTickClick = useCallback(
-    (value: string) => {
+    (e: MouseEvent, value: string) => {
+      e.stopPropagation();
       if (isCompareActive) return;
       void setLayers([{ ...layers?.[0], date: value }]);
     },
@@ -100,7 +105,7 @@ const Timeline: FC<{
                     className={cn('flex w-full items-center justify-center', {
                       'cursor-pointer': !isCompareActive,
                     })}
-                    onClick={() => handleTickClick(r.value)}
+                    onClick={(e) => handleTickClick(e, r.value)}
                   >
                     <div
                       className={cn('h-[6px] w-[1px] bg-white-800', {

--- a/src/containers/histogram/index.tsx
+++ b/src/containers/histogram/index.tsx
@@ -54,11 +54,23 @@ const Histogram: FC<HistogramProps> = ({ title, color, id }: HistogramProps) => 
         <p className="text-center text-sm text-gray-500">Loading histogram data...</p>
       )}
 
-      {!isLoadingDataHistogram && isRegionsLayerActive && histogramDataRegionRaw && (
-        <RegionsHistogram id={id} color={color} title={title} onCompareClose={onCloseCompareInfo} />
+      {!isLoadingDataHistogram &&
+        isRegionsLayerActive &&
+        !isErrorDataHistogram &&
+        histogramDataRegionRaw?.dataset?.length > 0 && (
+          <RegionsHistogram
+            id={id}
+            color={color}
+            title={title}
+            onCompareClose={onCloseCompareInfo}
+          />
+        )}
+      {!isLoadingDataHistogram && isRegionsLayerActive && isErrorDataHistogram && (
+        <p className="text-center text-sm text-secondary-500">
+          No statistics found for the given NUTS ID and layer ID
+        </p>
       )}
-      {((!isLoadingDataHistogram && !isRegionsLayerActive) ||
-        (isRegionsLayerActive && !histogramDataRegionRaw)) && (
+      {!isLoadingDataHistogram && !isRegionsLayerActive && (
         <PointHistogram color={color} title={title} id={id} />
       )}
     </div>

--- a/src/hooks/countries.ts
+++ b/src/hooks/countries.ts
@@ -1,0 +1,48 @@
+/**
+ * NUTS region country codes (ISO 3166-1 alpha-2) mapped to country names.
+ * Covers EU member states, EFTA, and candidate countries included in Eurostat NUTS.
+ */
+const COUNTRY_NAMES: Record<string, string> = {
+  AL: 'Albania',
+  AT: 'Austria',
+  BE: 'Belgium',
+  BG: 'Bulgaria',
+  CH: 'Switzerland',
+  CY: 'Cyprus',
+  CZ: 'Czechia',
+  DE: 'Germany',
+  DK: 'Denmark',
+  EE: 'Estonia',
+  EL: 'Greece',
+  ES: 'Spain',
+  FI: 'Finland',
+  FR: 'France',
+  HR: 'Croatia',
+  HU: 'Hungary',
+  IE: 'Ireland',
+  IS: 'Iceland',
+  IT: 'Italy',
+  LI: 'Liechtenstein',
+  LT: 'Lithuania',
+  LU: 'Luxembourg',
+  LV: 'Latvia',
+  ME: 'Montenegro',
+  MK: 'North Macedonia',
+  MT: 'Malta',
+  NL: 'Netherlands',
+  NO: 'Norway',
+  PL: 'Poland',
+  PT: 'Portugal',
+  RO: 'Romania',
+  RS: 'Serbia',
+  SE: 'Sweden',
+  SI: 'Slovenia',
+  SK: 'Slovakia',
+  TR: 'Turkey',
+  UK: 'United Kingdom',
+};
+
+export function useCountryName(code: string | null | undefined): string | null {
+  if (!code) return null;
+  return COUNTRY_NAMES[code] ?? code;
+}

--- a/src/hooks/layers.ts
+++ b/src/hooks/layers.ts
@@ -112,10 +112,21 @@ export function useLayerParsedSource(
   });
 }
 
+function toNumberOrNull(val: unknown): number | null {
+  if (val === null || val === undefined) return null;
+  if (typeof val === 'string' && val.toUpperCase() === 'NO DATA') return null;
+  const n = Number(val);
+  return Number.isFinite(n) ? n : null;
+}
+
 export function useNutsLayerData(
   params: { NUTS_ID?: string; LAYER_ID?: string; key: 'regular' | 'compare' } | undefined,
   queryOptions?: UseQueryOptions<
-    { dataset: { avg: number; label: string; max: number; min: number }[]; layer_id: string },
+    {
+      dataset?: { avg: number | null; label: string; max: number | null; min: number | null }[];
+      layer_id?: string;
+      error?: string;
+    },
     Error
   >
 ) {
@@ -131,7 +142,16 @@ export function useNutsLayerData(
         url: '/stats',
         params: { NUTS_ID: id, LAYER_ID: layer },
       });
-      return res.data;
+      const data = res.data;
+      if (data?.dataset) {
+        data.dataset = data.dataset.map((d: Record<string, unknown>) => ({
+          ...d,
+          avg: toNumberOrNull(d.avg),
+          min: toNumberOrNull(d.min),
+          max: toNumberOrNull(d.max),
+        }));
+      }
+      return data;
     },
     enabled: Boolean(NUTS_ID && LAYER_ID) && (queryOptions?.enabled ?? true),
     ...DEFAULT_QUERY_OPTIONS,

--- a/src/hooks/sync-query.ts
+++ b/src/hooks/sync-query.ts
@@ -45,7 +45,7 @@ export const useSyncDatasetType = () =>
 export const useSyncBasemapLabelsSettings = () =>
   useQueryState(
     'basemap-labels',
-    parseAsJson<'dark' | 'light' | 'no-label'>().withDefault('no-label')
+    parseAsJson<'dark' | 'light' | 'no-label'>().withDefault('light')
   );
 
 export const useSyncSearchGeostoriesGlobe = () =>

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -47,7 +47,7 @@ const isValidDate = (dateStr: string) => {
 export const transformNuqsData = (data: NuqsData) => {
   return (
     data?.dataset?.reduce((acc, { label, avg, max, min }) => {
-      if (Number.isNaN(Number(avg))) return acc;
+      if (avg === null || !Number.isFinite(avg)) return acc;
       let date = label;
       if (!isValidDate(label)) {
         const range = label.split('-');
@@ -61,8 +61,8 @@ export const transformNuqsData = (data: NuqsData) => {
         {
           x: date,
           y: avg,
-          max,
-          min,
+          max: Number.isFinite(max) ? max : null,
+          min: Number.isFinite(min) ? min : null,
         },
       ];
     }, []) || []

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -48,6 +48,7 @@ module.exports = {
         'accent-green': 'var(--accent-green)',
         black: {
           100: '#13273C',
+          150: '#112538',
           300: '#0E1D2D',
           400: '#0B1825',
           500: '#09131D',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",


### PR DESCRIPTION
- Timeline play/pause: add stopPropagation to prevent map click interference when clicking play/pause or timeline ticks
- Histogram: normalize API "NO DATA" strings to null, handle 404 error responses with user-facing message
- Legend: prevent overflow with truncated selects and title attrs for full text on hover
- Dataset card: auto-scroll sidebar to active card when histogram appears, add histogram-anchor id for scroll targeting
- LineChart: filter null y-values safely, protect against empty data
- Geostories view: clean up console.log, fix fragment wrapper
