### PR TITLE
perf: switch map layers to tiled WMS with smooth date transitions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,8 @@ FROM deps AS runner
 WORKDIR /app
 
 ENV NODE_ENV production
-ENV NEXT_PUBLIC_API_URL https://g3w.earthmonitor.org/dev
+ENV NEXT_PUBLIC_API_URL https://api.earthmonitor.org/dev
+ENV NEXT_PUBLIC_API_IMAGES_URL https://api.earthmonitor.org
 /
 # Uncomment the following line in case you want to disable telemetry during runtime.
 ENV NEXT_TELEMETRY_DISABLED 1

--- a/src/components/datasets/card/index.tsx
+++ b/src/components/datasets/card/index.tsx
@@ -39,15 +39,10 @@ const DatasetCard: FC<DatasetCardProps> = ({
   const [compareLayers, setCompareLayers] = useSyncCompareLayersSettings();
   // isActive is based on the url
   const isActive = useMemo(() => layers?.[0]?.id === id, [id, layers]);
-  const isCompareActive = useMemo(() => compareLayers?.[1]?.id === id, [id, compareLayers]);
+  const hasCompare = !!compareLayers?.[0]?.id;
 
   const [isHistogramActive] = useAtom(histogramVisibilityAtom);
   const cardRef = useRef<HTMLDivElement>(null);
-
-  const layerToCompareId = useMemo(() => {
-    if (!comparisonLayer) return null;
-    return compareLayers?.[0]?.id || comparisonLayer.layer_id || null;
-  }, [comparisonLayer, compareLayers]);
 
   const handleToggleLayer = useCallback(() => {
     if (!isActive) {
@@ -58,13 +53,15 @@ const DatasetCard: FC<DatasetCardProps> = ({
           date: range?.[0]?.value,
         },
       ]);
-      if (!isGeostory && range.length <= 1) void setCompareLayers(null);
-      if (!isGeostory && range.length > 1 && isCompareActive) {
+      if (!isGeostory && range.length <= 1) {
+        void setCompareLayers(null);
+      } else if (!isGeostory && hasCompare && range.length > 1) {
+        const newCompareId = comparisonLayer ? comparisonLayer.layer_id : id;
         void setCompareLayers([
           {
-            id: layerToCompareId,
+            id: newCompareId,
             opacity: compareLayers?.[0]?.opacity || 1,
-            date: range[range?.length - 1].value,
+            date: range[range.length - 1].value,
           },
         ]);
       }
@@ -75,13 +72,13 @@ const DatasetCard: FC<DatasetCardProps> = ({
   }, [
     id,
     isActive,
-    isCompareActive,
+    hasCompare,
     isGeostory,
     layers,
     range,
     setCompareLayers,
     setLayers,
-    layerToCompareId,
+    comparisonLayer,
     compareLayers,
   ]);
 

--- a/src/components/map/controls/index.tsx
+++ b/src/components/map/controls/index.tsx
@@ -3,7 +3,9 @@ import { useState, useMemo, FC, useCallback, ChangeEvent, lazy } from 'react';
 import { useMediaQuery } from 'react-responsive';
 
 import { Extent } from 'ol/extent';
+import TileLayer from 'ol/layer/Tile';
 import { fromLonLat } from 'ol/proj';
+import TileWMS from 'ol/source/TileWMS';
 import { RControl } from 'rlayers';
 
 import { cn } from '@/lib/classnames';
@@ -23,8 +25,8 @@ const SwipeControl = lazy(() => import('@/components/map/controls/swipe'));
 type ControlsProps = {
   className?: string;
   mapRef?: React.RefObject<any>;
-  layerRightRef?: React.RefObject<any>;
-  layerLeftRef?: React.RefObject<any>;
+  olLayerLeft?: TileLayer<TileWMS> | null;
+  olLayerRight?: TileLayer<TileWMS> | null;
   data?: any;
   isLoading?: boolean;
 };
@@ -36,8 +38,8 @@ interface ClickEvent {
 export const Controls: FC<ControlsProps> = ({
   className,
   mapRef,
-  layerLeftRef,
-  layerRightRef,
+  olLayerLeft,
+  olLayerRight,
   data,
   isLoading = false,
 }: ControlsProps) => {
@@ -137,7 +139,7 @@ export const Controls: FC<ControlsProps> = ({
         <ShareControl isMobile={isMobile} />
       </div>
       {isCompareLayerActive && data && !isLoading && (
-        <SwipeControl layerLeft={layerLeftRef} layerRight={layerRightRef} />
+        <SwipeControl olLayerLeft={olLayerLeft} olLayerRight={olLayerRight} />
       )}
     </div>
   );

--- a/src/components/map/controls/swipe/index.tsx
+++ b/src/components/map/controls/swipe/index.tsx
@@ -1,21 +1,24 @@
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 
 import type BaseEvent from 'ol/events/Event';
+import TileLayer from 'ol/layer/Tile';
+import TileWMS from 'ol/source/TileWMS';
 import Swipe from 'ol-ext/control/Swipe';
-import { RLayerWMS, useOL } from 'rlayers';
+import { useOL } from 'rlayers';
 
 import 'ol-ext/dist/ol-ext.css';
-import { useSyncSwipeControlPosition } from '@/hooks/sync-query';
-
-const swipeControl = new Swipe();
+import { useSyncSidebarState, useSyncSwipeControlPosition } from '@/hooks/sync-query';
 
 const SwipeControl: React.FC<{
-  layerLeft: React.RefObject<RLayerWMS>;
-  layerRight: React.RefObject<RLayerWMS>;
-}> = ({ layerLeft, layerRight }) => {
+  olLayerLeft?: TileLayer<TileWMS> | null;
+  olLayerRight?: TileLayer<TileWMS> | null;
+}> = ({ olLayerLeft, olLayerRight }) => {
   const [position, setPosition] = useSyncSwipeControlPosition();
-
+  const [sidebarOpen] = useSyncSidebarState();
   const { map } = useOL();
+  const swipeRef = useRef<Swipe | null>(null);
+  const sidebarOpenRef = useRef(sidebarOpen);
+  sidebarOpenRef.current = sidebarOpen;
 
   const handleMoving = useCallback(
     (e: BaseEvent & { position: number[] }) => {
@@ -25,31 +28,44 @@ const SwipeControl: React.FC<{
     [setPosition]
   );
 
+  // Create swipe control once, persist across layer changes
   useEffect(() => {
-    if (layerLeft && layerRight) {
-      const numericPos = position.side === 'left' ? position.x : 1 - position.x;
-      swipeControl.setProperties({ position: numericPos });
+    if (!map) return;
 
-      // swipeControl.setProperties({ position: numericPos });
-      // Boolean indicates if the layer is on the right side
-      swipeControl.addLayer([layerLeft?.current?.ol], false);
-      swipeControl.addLayer([layerRight?.current?.ol], true);
-    } else {
-      swipeControl.removeLayer([layerLeft?.current?.ol]);
-      swipeControl.removeLayer([layerRight?.current?.ol]);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [layerLeft, layerRight]);
+    const swipe = new Swipe();
+    swipeRef.current = swipe;
 
-  useEffect(() => {
-    map?.addControl(swipeControl);
-    swipeControl.addEventListener('moving', handleMoving);
+    // Center swipe on visible map area (sidebar overlaps left side)
+    const mapWidth = map.getTargetElement()?.clientWidth || window.innerWidth;
+    const sidebarPx = sidebarOpenRef.current ? 536 : 48; // 28rem + 88px or 3rem
+    const visibleCenter = Math.min(0.9, Math.max(0.1, sidebarPx / (2 * mapWidth) + 0.5));
+    swipe.setProperties({ position: visibleCenter });
+    void setPosition({ side: 'left', x: visibleCenter });
+
+    map.addControl(swipe);
+    swipe.addEventListener('moving', handleMoving);
 
     return () => {
-      map.removeControl(swipeControl);
-      swipeControl.removeEventListener('moving', handleMoving);
+      swipe.removeEventListener('moving', handleMoving);
+      (swipe as any).removeLayers();
+      map.removeControl(swipe);
+      swipeRef.current = null;
     };
-  }, [handleMoving, map]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [map, handleMoving]);
+
+  // Update layers when they change — swipe control stays
+  useEffect(() => {
+    const swipe = swipeRef.current;
+    if (!swipe) return;
+
+    (swipe as any).removeLayers();
+
+    if (olLayerLeft && olLayerRight) {
+      swipe.addLayer(olLayerLeft, false);
+      swipe.addLayer(olLayerRight, true);
+    }
+  }, [olLayerLeft, olLayerRight]);
 
   return null;
 };

--- a/src/components/map/index.tsx
+++ b/src/components/map/index.tsx
@@ -10,9 +10,10 @@ import type { MapBrowserEvent } from 'ol';
 import * as ol from 'ol';
 import type { Coordinate } from 'ol/coordinate';
 import { toLonLat } from 'ol/proj';
+import TileLayer from 'ol/layer/Tile';
 import { Size } from 'ol/size';
 import TileWMS from 'ol/source/TileWMS';
-import { RLayerTile, RLayerWMS, RMap } from 'rlayers';
+import { RLayerTile, RMap } from 'rlayers';
 
 import { getHistogramData } from '@/lib/utils';
 import { fetchFeatureInfo, getFeatureInfoUrl, firstPropertyValue } from '@/lib/wms';
@@ -56,6 +57,7 @@ import {
 } from './constants';
 // map controls
 import Controls from './controls';
+import BufferedTileWMS from './layers/buffered-tile-wms';
 import NutsLayer from './layers/nuts';
 import Legend from './legend';
 import MapTooltip from './tooltip';
@@ -162,8 +164,8 @@ const Map: FC<CustomMapProps> = ({ initialViewState = DEFAULT_VIEWPORT }) => {
     };
   }> = useRef(null as unknown as any);
 
-  const layerLeftRef = useRef(null);
-  const layerRightRef = useRef(null);
+  const [olLayerLeft, setOlLayerLeft] = useState<TileLayer<TileWMS> | null>(null);
+  const [olLayerRight, setOlLayerRight] = useState<TileLayer<TileWMS> | null>(null);
   const hasInitializedComparativeGeostory = useRef(false);
 
   const [tooltipInfo, setTooltipInfo] = useState<MonitorTooltipInfo>(TOOLTIP_INITIAL_STATE);
@@ -178,7 +180,10 @@ const Map: FC<CustomMapProps> = ({ initialViewState = DEFAULT_VIEWPORT }) => {
   const compareDate = compareLayers?.[0]?.date;
   const isCompareLayerActive = !!compareLayerId;
 
-  const { data: compareData } = useLayer({ layer_id: compareLayerId });
+  const { data: compareData } = useLayer(
+    { layer_id: compareLayerId },
+    { enabled: !!compareLayerId }
+  );
 
   const {
     gs_name: compareGsName,
@@ -499,43 +504,21 @@ const Map: FC<CustomMapProps> = ({ initialViewState = DEFAULT_VIEWPORT }) => {
         <BasemapLayer />
 
         {!isLoading && isLayerActive && !!gs_name && (
-          <RLayerWMS
-            ref={layerLeftRef}
-            properties={{ label: gs_name, date }}
+          <BufferedTileWMS
             url={gs_base_wms}
+            layerName={gs_name}
+            date={date}
             opacity={opacity ?? 1}
-            params={{
-              FORMAT: 'image/png',
-              SERVICE: 'WMS',
-              VERSION: '1.3.0',
-              REQUEST: 'GetMap',
-              TRANSPARENT: true,
-              LAYERS: gs_name,
-              DIM_DATE: date,
-              CRS: WMS_CRS,
-              BBOX: 'bbox-epsg-3857',
-            }}
+            onLayerChange={setOlLayerLeft}
           />
         )}
-
         {!isLoading && isCompareLayerActive && !!compareGsName && (
-          <RLayerWMS
-            ref={layerRightRef}
-            properties={{ label: compareGsName, date: compareDate }}
+          <BufferedTileWMS
             url={compareGsBaseWms}
+            layerName={compareGsName}
+            date={compareDate}
             opacity={opacity ?? 1}
-            params={{
-              FORMAT: 'image/png',
-              SERVICE: 'WMS',
-              VERSION: '1.3.0',
-              REQUEST: 'GetMap',
-              TRANSPARENT: true,
-              LAYERS: compareGsName,
-              // DIM_DATE: compareDate,
-              CRS: WMS_CRS,
-              BBOX: 'bbox-epsg-3857',
-            }}
-            visible={isCompareLayerActive}
+            onLayerChange={setOlLayerRight}
           />
         )}
 
@@ -552,8 +535,8 @@ const Map: FC<CustomMapProps> = ({ initialViewState = DEFAULT_VIEWPORT }) => {
 
         <Controls
           mapRef={mapRef}
-          layerLeftRef={layerLeftRef}
-          layerRightRef={layerRightRef}
+          olLayerLeft={olLayerLeft}
+          olLayerRight={olLayerRight}
           data={dataMeta}
           isLoading={isLoading}
         />

--- a/src/components/map/layers/buffered-tile-wms.tsx
+++ b/src/components/map/layers/buffered-tile-wms.tsx
@@ -4,17 +4,13 @@ import { FC, useEffect, useRef } from 'react';
 
 import TileLayer from 'ol/layer/Tile';
 import TileWMS from 'ol/source/TileWMS';
-import { useOL } from 'rlayers';
+import { RLayerTileWMSProps, useOL } from 'rlayers';
 
 import { WMS_CRS } from '../constants';
 
-interface BufferedTileWMSProps {
-  url: string;
+interface BufferedTileWMSProps extends RLayerTileWMSProps {
   layerName: string;
   date: string | undefined;
-  opacity?: number;
-  zIndex?: number;
-  visible?: boolean;
   onLayerChange?: (layer: TileLayer<TileWMS> | null) => void;
 }
 
@@ -24,11 +20,21 @@ interface BufferedTileWMSProps {
  */
 const BufferedTileWMS: FC<BufferedTileWMSProps> = ({
   url,
+  params,
   layerName,
   date,
   opacity = 1,
   zIndex = 1,
   visible = true,
+  minResolution,
+  maxResolution,
+  minZoom,
+  maxZoom,
+  projection,
+  attributions,
+  cacheSize,
+  wrapX,
+  properties,
   onLayerChange,
 }) => {
   const { map } = useOL();
@@ -50,9 +56,14 @@ const BufferedTileWMS: FC<BufferedTileWMSProps> = ({
         TILED: true,
         DIM_DATE: dateRef.current,
         CRS: WMS_CRS,
+        ...params,
       },
       serverType: 'geoserver',
       crossOrigin: 'anonymous',
+      projection,
+      attributions,
+      cacheSize,
+      wrapX,
     });
 
     const layer = new TileLayer({
@@ -60,6 +71,11 @@ const BufferedTileWMS: FC<BufferedTileWMSProps> = ({
       opacity,
       zIndex,
       visible,
+      minResolution,
+      maxResolution,
+      minZoom,
+      maxZoom,
+      properties,
     });
 
     layerRef.current = layer;

--- a/src/components/map/layers/buffered-tile-wms.tsx
+++ b/src/components/map/layers/buffered-tile-wms.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import { FC, useEffect, useRef } from 'react';
+
+import TileLayer from 'ol/layer/Tile';
+import TileWMS from 'ol/source/TileWMS';
+import { useOL } from 'rlayers';
+
+import { WMS_CRS } from '../constants';
+
+interface BufferedTileWMSProps {
+  url: string;
+  layerName: string;
+  date: string | undefined;
+  opacity?: number;
+  zIndex?: number;
+  visible?: boolean;
+  onLayerChange?: (layer: TileLayer<TileWMS> | null) => void;
+}
+
+/**
+ * WMS tile layer that uses OL's native `updateParams()` for date changes.
+ * Old tiles stay visible as interim tiles until new ones load — no blink.
+ */
+const BufferedTileWMS: FC<BufferedTileWMSProps> = ({
+  url,
+  layerName,
+  date,
+  opacity = 1,
+  zIndex = 1,
+  visible = true,
+  onLayerChange,
+}) => {
+  const { map } = useOL();
+  const layerRef = useRef<TileLayer<TileWMS> | null>(null);
+  const dateRef = useRef(date);
+  dateRef.current = date;
+  const onLayerChangeRef = useRef(onLayerChange);
+  onLayerChangeRef.current = onLayerChange;
+
+  // Create layer + source once; recreate only on url/layerName change
+  useEffect(() => {
+    if (!map) return;
+
+    const source = new TileWMS({
+      url,
+      params: {
+        FORMAT: 'image/png',
+        LAYERS: layerName,
+        TILED: true,
+        DIM_DATE: dateRef.current,
+        CRS: WMS_CRS,
+      },
+      serverType: 'geoserver',
+      crossOrigin: 'anonymous',
+    });
+
+    const layer = new TileLayer({
+      source,
+      opacity,
+      zIndex,
+      visible,
+    });
+
+    layerRef.current = layer;
+    map.addLayer(layer);
+    onLayerChangeRef.current?.(layer);
+
+    return () => {
+      map.removeLayer(layer);
+      layerRef.current = null;
+      onLayerChangeRef.current?.(null);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [map, url, layerName]);
+
+  // Date change → updateParams keeps old tiles visible until new ones load
+  useEffect(() => {
+    layerRef.current?.getSource()?.updateParams({ DIM_DATE: date });
+  }, [date]);
+
+  useEffect(() => {
+    layerRef.current?.setOpacity(opacity);
+  }, [opacity]);
+
+  useEffect(() => {
+    layerRef.current?.setVisible(visible);
+  }, [visible]);
+
+  useEffect(() => {
+    layerRef.current?.setZIndex(zIndex);
+  }, [zIndex]);
+
+  return null;
+};
+
+export default BufferedTileWMS;

--- a/src/components/map/layers/index.tsx
+++ b/src/components/map/layers/index.tsx
@@ -10,7 +10,7 @@ import * as ol from 'ol';
 import type { Coordinate } from 'ol/coordinate';
 import { Size } from 'ol/size';
 import TileWMS from 'ol/source/TileWMS';
-import { RLayerTile, RLayerWMS } from 'rlayers';
+import { RLayerTile } from 'rlayers';
 
 import { fetchFeatureInfo, getFeatureInfoUrl, firstPropertyValue } from '@/lib/wms';
 
@@ -38,6 +38,7 @@ import type { CustomMapProps, MonitorTooltipInfo } from '@/components/map/types'
 import BasemapLayer from '../basemap';
 import { DEFAULT_VIEWPORT, TOOLTIP_INITIAL_STATE, WMS_INFO_FORMAT, WMS_CRS } from '../constants';
 
+import BufferedTileWMS from './buffered-tile-wms';
 import NutsLayer from './nuts';
 
 function buildWmsSource(url: string, layerName: string) {
@@ -131,8 +132,6 @@ const MapLayers: FC<CustomMapProps> = ({ initialViewState = DEFAULT_VIEWPORT }) 
     };
   }> = useRef(null as unknown as any);
 
-  const layerLeftRef = useRef(null);
-  const layerRightRef = useRef(null);
   const nutsLayer = useRef(null);
 
   const [tooltipInfo, setTooltipInfo] = useState<MonitorTooltipInfo>(TOOLTIP_INITIAL_STATE);
@@ -362,41 +361,14 @@ const MapLayers: FC<CustomMapProps> = ({ initialViewState = DEFAULT_VIEWPORT }) 
       <BasemapLayer />
 
       {dataMeta && !isLoadingLayerFromURL && isLayerActive && !!gs_name && (
-        <RLayerWMS
-          ref={layerLeftRef}
-          properties={{ label: gs_name, date }}
-          url={gs_base_wms}
-          opacity={opacity ?? 1}
-          params={{
-            FORMAT: 'image/png',
-            SERVICE: 'WMS',
-            VERSION: '1.3.0',
-            REQUEST: 'GetMap',
-            TRANSPARENT: true,
-            LAYERS: gs_name,
-            DIM_DATE: date,
-            CRS: WMS_CRS,
-            BBOX: 'bbox-epsg-3857',
-          }}
-        />
+        <BufferedTileWMS url={gs_base_wms} layerName={gs_name} date={date} opacity={opacity ?? 1} />
       )}
       {dataMeta && !isLoadingLayerFromURL && isCompareLayerActive && !!compareGsName && (
-        <RLayerWMS
-          ref={layerRightRef}
-          properties={{ label: compareGsName }}
+        <BufferedTileWMS
           url={compareGsBaseWms}
+          layerName={compareGsName}
+          date={compareDate}
           opacity={opacity ?? 1}
-          params={{
-            FORMAT: 'image/png',
-            SERVICE: 'WMS',
-            VERSION: '1.3.0',
-            REQUEST: 'GetMap',
-            TRANSPARENT: true,
-            LAYERS: compareGsName,
-            CRS: WMS_CRS,
-            BBOX: 'bbox-epsg-3857',
-          }}
-          visible={isCompareLayerActive}
         />
       )}
 

--- a/src/components/map/legend/component.tsx
+++ b/src/components/map/legend/component.tsx
@@ -13,8 +13,8 @@ import { ScrollArea } from '@/components/ui/scroll-area';
 import LegendGraphic from './graphic';
 import OpacitySetting from './opacity';
 import RemoveLayer from './remove';
-import LayerVisibility from './visibility';
 import LegendTimeseries from './timelime';
+import LayerVisibility from './visibility';
 
 export const Legend: React.FC<{ children?: React.ReactNode }> = ({ children }) => {
   const [layers] = useSyncLayersSettings();
@@ -98,7 +98,7 @@ export const Legend: React.FC<{ children?: React.ReactNode }> = ({ children }) =
           isFetchedLayerData &&
           !isLoadingLegendData &&
           isFetchedLegendData && <LegendGraphic dataLayer={layerData} dataLegend={legendData} />}
-        {isGeostory && compareLayerData && (
+        {isGeostory && compareLayerData && compareLayers?.[0]?.id !== layerId && (
           <div
             className="flex w-full flex-col space-y-4 rounded-b-sm border-gray-600 bg-brand-500"
             style={{ minWidth: legendWidth }}
@@ -109,14 +109,14 @@ export const Legend: React.FC<{ children?: React.ReactNode }> = ({ children }) =
             >
               <div
                 data-testid="map-legend-item-title"
-                className="min-w-0 truncate text-xs font-bold"
+                className="min-w-0 max-w-[60%] line-clamp-2 text-xs font-bold"
                 ref={titleRef}
                 title={compareLayerData.title}
               >
                 {compareLayerData.title}
               </div>
               <div
-                className="flex space-x-2 divide-x divide-secondary-800"
+                className="flex shrink-0 space-x-2 divide-x divide-secondary-800"
                 data-testid="map-legend-item-toolbar"
               >
                 <div className="flex space-x-2">

--- a/src/components/map/legend/index.tsx
+++ b/src/components/map/legend/index.tsx
@@ -46,7 +46,7 @@ export const Legend: React.FC<{
   return (
     <div
       className={cn({
-        'absolute bottom-0 right-0  hidden w-full justify-end border-t border-secondary-900 bg-brand-500 sm:max-w-sm sm:space-y-1 sm:border-0 sm:bg-transparent sm:shadow-lg md:flex':
+        'absolute bottom-0 right-0 hidden w-full justify-end border-t border-secondary-900 bg-brand-500 sm:max-w-md sm:space-y-1 sm:border-0 sm:bg-transparent sm:shadow-lg md:flex':
           true,
         'z-[700]': isMobile,
         'z-[50]': !isMobile,
@@ -67,11 +67,15 @@ export const Legend: React.FC<{
               className="relative flex flex-1 items-start justify-between space-x-4 text-white-500"
               data-testid="map-legend-item"
             >
-              <div data-testid="map-legend-item-title" className="min-w-0 truncate" title={title}>
+              <div
+                data-testid="map-legend-item-title"
+                className="min-w-0 max-w-[60%] line-clamp-2"
+                title={title}
+              >
                 {title}
               </div>
               <div
-                className="flex space-x-2 divide-x divide-secondary-800"
+                className="flex shrink-0 space-x-2 divide-x divide-secondary-800"
                 data-testid="map-legend-item-toolbar"
               >
                 <div className="flex space-x-2">

--- a/src/components/map/legend/timelime.tsx
+++ b/src/components/map/legend/timelime.tsx
@@ -80,6 +80,7 @@ export const LegendTimeseries: React.FC = () => {
           layerId={comparisonLayerId}
           range={mainLayer?.range}
           isActive={true}
+          hideTimeline={!!baseLayerData?.range?.length}
         />
       )}
     </div>

--- a/src/components/map/stats/point-histogram.tsx
+++ b/src/components/map/stats/point-histogram.tsx
@@ -50,12 +50,13 @@ const PointHistogram: FC<GeostoryTooltipInfo> = ({ title, color, id }: GeostoryT
     regex,
   };
 
-  const { data: histogramData, isLoading: isLoadingHistogram } = usePointData(
-    layerPointInfoPayload,
-    {
-      enabled: !!lonLat,
-    }
-  );
+  const {
+    data: histogramData,
+    isLoading: isLoadingHistogram,
+    error: histogramError,
+  } = usePointData(layerPointInfoPayload, {
+    enabled: !!lonLat && !!regex,
+  });
 
   const histogramPointData = useMemo(() => {
     return {
@@ -109,16 +110,23 @@ const PointHistogram: FC<GeostoryTooltipInfo> = ({ title, color, id }: GeostoryT
             onClick={handleClick}
             className={cn({
               'flex w-full items-center justify-end space-x-2': true,
-              'opacity-50': !histogramData,
+              'opacity-50': !histogramData || !!histogramError,
             })}
-            disabled={!histogramData}
+            disabled={!histogramData || !!histogramError}
           >
             <FiDownload className="h-3.5 w-3.5" />
             <span className="font-inter text-xs">CSV</span>
           </button>
         </div>
         {isLoadingHistogram && <Loading />}
-        {!isLoadingHistogram && (
+        {!isLoadingHistogram && histogramError && (
+          <p className="text-sm text-alert-error">
+            Error occurred while fetching the data:{' '}
+            {(histogramError.response?.data as { message?: string })?.message ||
+              histogramError.message}
+          </p>
+        )}
+        {!isLoadingHistogram && !histogramError && (
           <div className="relative h-full w-full">
             <LineChart data={histogramPointData} color={color} />
           </div>

--- a/src/components/sidebar/card-header.tsx
+++ b/src/components/sidebar/card-header.tsx
@@ -1,5 +1,4 @@
-import Link from 'next/link';
-import { useParams } from 'next/navigation';
+import { useParams, useRouter } from 'next/navigation';
 
 import cn from '@/lib/classnames';
 
@@ -26,6 +25,7 @@ const CardHeader: React.FC<CardHeaderProps> = ({
   bbox,
 }) => {
   const params = useParams();
+  const router = useRouter();
   const geostoryId = params.geostory_id;
 
   const handleClick = () => {
@@ -33,6 +33,7 @@ const CardHeader: React.FC<CardHeaderProps> = ({
       geostory_id: geostoryId,
     });
     console.info('WT2 -', type, id);
+    router.push(`/explore/${type === 'monitor' ? 'monitor' : 'geostory'}/${id}?bbox=${bbox}`);
   };
 
   return (
@@ -49,11 +50,11 @@ const CardHeader: React.FC<CardHeaderProps> = ({
           {theme}
         </span>
       </div>
-      <Link
-        href={`/explore/${type === 'monitor' ? 'monitor' : 'geostory'}/${id}?bbox=${bbox}`}
+      <button
+        type="button"
         onClick={handleClick}
         data-testid={`card-title-link-${id}`}
-        className="focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-green rounded"
+        className="text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-green rounded"
       >
         <h2
           style={{ color }}
@@ -61,7 +62,7 @@ const CardHeader: React.FC<CardHeaderProps> = ({
         >
           {title}
         </h2>
-      </Link>
+      </button>
     </div>
   );
 };

--- a/src/components/timeseries-comparative-layers/index.tsx
+++ b/src/components/timeseries-comparative-layers/index.tsx
@@ -1,4 +1,8 @@
-import { useEffect, useMemo, useCallback, useState } from 'react';
+import { useMemo, useCallback, useState } from 'react';
+
+import { useAtom } from 'jotai';
+
+import { timeSeriesPlaybackAtom } from '@/app/store';
 import type { FC } from 'react';
 
 import { LuX } from 'react-icons/lu';
@@ -27,37 +31,32 @@ const TimeSeriesComparativeLayers: FC<{
   layerId: LayerParsed['layer_id'];
   range: LayerParsed['range'];
   isActive: boolean;
-}> = ({ range, isActive, layerId }) => {
+  hideTimeline?: boolean;
+}> = ({ range, isActive, layerId, hideTimeline = false }) => {
   const [layers, setLayers] = useSyncLayersSettings();
   const [comparisonLayers, setComparisonLayers] = useSyncCompareLayersSettings();
 
-  const keyFor = (id: string) => `timeseries:${id}:playing`;
-
-  const [isPlaying, setPlaying] = useState<boolean>(true);
+  const [isPlaying, setPlaying] = useAtom(timeSeriesPlaybackAtom);
 
   const comparisonLayerId = useMemo(() => comparisonLayers?.[0]?.id, [comparisonLayers]);
-
-  useEffect(() => {
-    if (!layerId) return;
-    sessionStorage.setItem(keyFor(layerId), JSON.stringify(isPlaying));
-  }, [layerId, isPlaying]);
 
   const opacity = layers?.[0]?.opacity;
   const [contentVisibility, setContentVisibility] = useState<boolean>(false);
 
   const handleSelect = useCallback(
     (value: string) => {
-      const nextRange = range.find((r) => r.value === value);
+      setPlaying(false);
+      const nextRange = range?.find((r) => r.value === value);
       void setLayers([{ id: layerId, opacity, date: nextRange?.value }]);
       setContentVisibility(false);
     },
-    [layerId, opacity, range, setLayers, setContentVisibility]
+    [layerId, opacity, range, setLayers, setContentVisibility, setPlaying]
   );
 
   const date = layers?.[0]?.date;
 
   const currentRange = useMemo(
-    () => range.find((r) => r.value === date) ?? range[0],
+    () => range?.find((r) => r.value === date) ?? range?.[0],
     [date, range]
   );
 
@@ -104,7 +103,7 @@ const TimeSeriesComparativeLayers: FC<{
                 style={{ width: 'calc(100% - 2rem)' }}
               >
                 <ScrollArea className="max-h-[200px] w-full">
-                  {range.map((r: LayerDateRange) => (
+                  {range?.map((r: LayerDateRange) => (
                     <SelectItem key={r.value} value={r.value} className="px-2">
                       {r?.label}
                     </SelectItem>
@@ -144,16 +143,18 @@ const TimeSeriesComparativeLayers: FC<{
           )}
         </div>
       </div>
-      {/* Timeline */}
-      <Timeline
-        layerId={layerId}
-        range={range}
-        isActive={isActive}
-        defaultActive={true}
-        autoPlay={true}
-        isPlaying={isPlaying}
-        setPlaying={setPlaying}
-      />
+      {/* Timeline — hidden when TimeSeriesSameLayer already provides one */}
+      {!hideTimeline && (
+        <Timeline
+          layerId={layerId}
+          range={range}
+          isActive={isActive}
+          defaultActive={true}
+          autoPlay={true}
+          isPlaying={isPlaying}
+          setPlaying={setPlaying}
+        />
+      )}
     </div>
   );
 };

--- a/src/components/timeseries-comparative-layers/timeline.tsx
+++ b/src/components/timeseries-comparative-layers/timeline.tsx
@@ -39,12 +39,12 @@ const Timeline: FC<{
   const date = layers?.[0]?.date;
 
   const currentRange = useMemo(
-    () => range.find((r) => r.value === date) ?? range[0],
+    () => range?.find((r) => r.value === date) ?? range?.[0],
     [date, range]
   );
 
   const currentIndex = useMemo(
-    () => Math.max(0, range.findIndex((r) => r.value === currentRange?.value)),
+    () => Math.max(0, range?.findIndex((r) => r.value === currentRange?.value) ?? 0),
     [range, currentRange]
   );
 
@@ -55,6 +55,7 @@ const Timeline: FC<{
 
   useInterval(
     () => {
+      if (!range?.length) return;
       const nextRange = range[(range.indexOf(currentRange) + 1) % range.length];
       void setLayers([{ ...layers?.[0], date: nextRange.value }]);
     },
@@ -72,7 +73,7 @@ const Timeline: FC<{
 
   const handleSliderChange = useCallback(
     (index: number) => {
-      void setLayers([{ ...layers?.[0], date: range[index].value }]);
+      void setLayers([{ ...layers?.[0], date: range?.[index]?.value }]);
     },
     [layers, setLayers, range]
   );
@@ -81,25 +82,20 @@ const Timeline: FC<{
   const endRangelabel = useMemo(() => range && range[range.length - 1]?.label, [range]);
 
   return (
-    <Tooltip delayDuration={0}>
-      <TooltipTrigger disabled={isCompareActive} asChild>
-        <div className="flex w-full items-center space-x-3 py-3.5">
-          <button
-            type="button"
-            onClick={handleTogglePlay}
-            disabled={isCompareActive}
-            className="pointer-events-auto"
-          >
-            {isPlaying && isActive ? (
-              <LuCirclePause className="h-6 w-6 text-accent-green" />
-            ) : (
-              <LuCirclePlay className="h-6 w-6 text-secondary-500" />
-            )}
-          </button>
+    <div className="flex w-full items-center space-x-3 py-3.5">
+      <button type="button" onClick={handleTogglePlay}>
+        {isPlaying && isActive ? (
+          <LuCirclePause className="h-6 w-6 text-accent-green" />
+        ) : (
+          <LuCirclePlay className="h-6 w-6 text-secondary-500" />
+        )}
+      </button>
+      <Tooltip delayDuration={0}>
+        <TooltipTrigger asChild>
           <div className="relative flex w-full flex-col space-y-2 bg-white-950">
             <div className="max-w flex w-full overflow-hidden">
-              {range.length <= TICK_THRESHOLD ? (
-                range.map((r) => (
+              {(range?.length ?? 0) <= TICK_THRESHOLD ? (
+                range?.map((r) => (
                   <div
                     key={r.value}
                     className={cn('flex w-full items-center justify-center', {
@@ -118,7 +114,7 @@ const Timeline: FC<{
                 <input
                   type="range"
                   min={0}
-                  max={range.length - 1}
+                  max={(range?.length ?? 1) - 1}
                   value={currentIndex}
                   disabled={isCompareActive}
                   onChange={(e) => handleSliderChange(Number(e.target.value))}
@@ -136,30 +132,30 @@ const Timeline: FC<{
               </div>
             </div>
           </div>
-        </div>
-      </TooltipTrigger>
+        </TooltipTrigger>
 
-      <TooltipPortal>
-        <TooltipContent
-          sideOffset={20}
-          side="left"
-          align="center"
-          className={cn({
-            'border-none bg-black-400 text-white-500': true,
-            hidden: !isCompareActive,
-          })}
-        >
-          <div className="max-w-xs text-sm">
-            <p>
-              When the layer comparison functionality is enabled, the timeline is automatically
-              paused .
-            </p>
-            <p>To activate the timeline again, comparison mode must first be disabled.</p>
-          </div>
-          <TooltipArrow />
-        </TooltipContent>
-      </TooltipPortal>
-    </Tooltip>
+        <TooltipPortal>
+          <TooltipContent
+            sideOffset={20}
+            side="left"
+            align="center"
+            className={cn({
+              'border-none bg-black-400 text-white-500': true,
+              hidden: !isCompareActive,
+            })}
+          >
+            <div className="max-w-xs text-sm">
+              <p>
+                When the layer comparison functionality is enabled, the timeline is automatically
+                paused .
+              </p>
+              <p>To activate the timeline again, comparison mode must first be disabled.</p>
+            </div>
+            <TooltipArrow />
+          </TooltipContent>
+        </TooltipPortal>
+      </Tooltip>
+    </div>
   );
 };
 

--- a/src/components/timeseries-layer/index.tsx
+++ b/src/components/timeseries-layer/index.tsx
@@ -1,4 +1,8 @@
-import { useEffect, useMemo, useCallback, useState, useRef } from 'react';
+import { useMemo, useCallback, useState } from 'react';
+
+import { useAtom } from 'jotai';
+
+import { timeSeriesPlaybackAtom } from '@/app/store';
 import type { FC } from 'react';
 
 import { LuX } from 'react-icons/lu';
@@ -33,35 +37,7 @@ const TimeSeriesSameLayer: FC<{
   const [layers, setLayers] = useSyncLayersSettings();
   const [compareLayers, setCompareLayers] = useSyncCompareLayersSettings();
 
-  const keyFor = (id: string) => `timeseries:${id}:playing`;
-
-  const initRef = useRef(false);
-
-  const [isPlaying, setPlaying] = useState<boolean>(false);
-  useEffect(() => {
-    if (!layerId || initRef.current) return;
-
-    const key = keyFor(layerId);
-    let initial = false;
-
-    const saved = sessionStorage.getItem(key);
-    if (saved !== null) {
-      try {
-        initial = JSON.parse(saved);
-      } catch {}
-    } else {
-      initial = !!(autoPlay && defaultActive && isActive);
-    }
-
-    setPlaying(initial);
-    initRef.current = true;
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [layerId]);
-
-  useEffect(() => {
-    if (!layerId) return;
-    sessionStorage.setItem(keyFor(layerId), JSON.stringify(isPlaying));
-  }, [layerId, isPlaying]);
+  const [isPlaying, setPlaying] = useAtom(timeSeriesPlaybackAtom);
 
   const opacity = layers?.[0]?.opacity;
   const [contentVisibility, setContentVisibility] = useState<boolean>(false);
@@ -69,20 +45,22 @@ const TimeSeriesSameLayer: FC<{
 
   const handleSelect = useCallback(
     (value: string) => {
-      const nextRange = range.find((r) => r.value === value);
-      void setLayers([{ id: layerId, opacity, date: nextRange.value }]);
+      setPlaying(false);
+      const nextRange = range?.find((r) => r.value === value);
+      void setLayers([{ id: layerId, opacity, date: nextRange?.value }]);
       setContentVisibility(false);
     },
-    [layerId, opacity, range, setLayers, setContentVisibility]
+    [layerId, opacity, range, setLayers, setContentVisibility, setPlaying]
   );
 
   const handleCompareSelect = useCallback(
     (value: string) => {
-      const nextRange = range.find((r) => r.value === value);
-      void setCompareLayers([{ id: layerId, opacity, date: nextRange.value }]);
+      setPlaying(false);
+      const nextRange = range?.find((r) => r.value === value);
+      void setCompareLayers([{ id: layerId, opacity, date: nextRange?.value }]);
       setContentVisibility(false);
     },
-    [layerId, opacity, range, setContentVisibility, setCompareLayers]
+    [layerId, opacity, range, setContentVisibility, setCompareLayers, setPlaying]
   );
 
   const date = layers?.[0]?.date;
@@ -90,21 +68,18 @@ const TimeSeriesSameLayer: FC<{
   const compareDate = compareLayers?.[0]?.date;
 
   const currentRange = useMemo(
-    () => range.find((r) => r.value === date) ?? range[0],
+    () => range?.find((r) => r.value === date) ?? range?.[0],
     [date, range]
   );
   const compareCurrentRange = useMemo(
     () =>
       compareLayers && compareLayers.length > 0 && compareDate
-        ? range.find((r) => r.value === compareDate) ?? range[0]
+        ? range?.find((r) => r.value === compareDate) ?? range?.[0]
         : null,
     [compareDate, compareLayers, range]
   );
 
-  const isCompareActive = useMemo(
-    () => compareLayers?.[0]?.id === layerId,
-    [layerId, compareLayers]
-  );
+  const hasAnyCompare = !!compareLayers?.[0]?.id;
 
   return (
     <div className="flex w-full flex-col">
@@ -112,7 +87,7 @@ const TimeSeriesSameLayer: FC<{
       <div className="flex flex-col space-y-2 text-secondary-500">
         <span className="text-sm">Select date:</span>
         <div className="flex w-full items-center justify-between gap-4">
-          {currentRange && range.length > 1 && (
+          {currentRange && (range?.length ?? 0) > 1 && (
             <Select
               value={currentRange.value}
               onValueChange={handleSelect}
@@ -138,7 +113,7 @@ const TimeSeriesSameLayer: FC<{
                 style={{ width: 'calc(100% - 2rem)' }}
               >
                 <ScrollArea className="max-h-[200px] w-full">
-                  {range.map((r: LayerDateRange) => (
+                  {range?.map((r: LayerDateRange) => (
                     <SelectItem key={r.value} value={r.value} className="px-2">
                       {r?.label}
                     </SelectItem>
@@ -147,12 +122,12 @@ const TimeSeriesSameLayer: FC<{
               </SelectContent>
             </Select>
           )}
-          {currentRange && range.length === 1 && (
+          {currentRange && (range?.length ?? 0) === 1 && (
             <div className="min-w-0 max-w-[50%] text-xs font-semibold">
               <div
                 className={cn(
                   buttonVariants({ variant: 'outline', size: 'sm' }),
-                  'w-full justify-between hover:bg-transparent truncate'
+                  'w-full justify-between truncate hover:bg-transparent'
                 )}
                 title={currentRange?.label}
               >
@@ -160,23 +135,23 @@ const TimeSeriesSameLayer: FC<{
               </div>
             </div>
           )}
-          {!isCompareActive && (
+          {!hasAnyCompare && (
             <Button
               variant="outline"
               size="sm"
               className="text-xs font-semibold"
-              disabled={range.length <= 1}
+              disabled={(range?.length ?? 0) <= 1}
               onClick={() => {
                 setPlaying(false);
-                setCompareLayers([{ id: layerId, opacity, date: range[0].value }]);
+                setCompareLayers([{ id: layerId, opacity, date: range?.[0]?.value }]);
               }}
             >
               Compare
             </Button>
           )}
-          {compareCurrentRange && range.length > 1 && (
+          {compareCurrentRange && (range?.length ?? 0) > 1 && (
             <Select
-              value={compareCurrentRange?.value || range[0].value}
+              value={compareCurrentRange?.value || range?.[0]?.value}
               disabled={isPlaying}
               onValueChange={handleCompareSelect}
               open={contentCompareVisibility}
@@ -190,11 +165,9 @@ const TimeSeriesSameLayer: FC<{
                     buttonVariants({ variant: 'outline', size: 'sm' }),
                     'w-full justify-between overflow-hidden hover:bg-transparent'
                   )}
-                  title={compareCurrentRange?.label || range[0].label}
+                  title={compareCurrentRange?.label || range?.[0]?.label}
                 >
-                  <SelectValue>
-                    {compareCurrentRange?.label || range[0].label}
-                  </SelectValue>
+                  <SelectValue>{compareCurrentRange?.label || range?.[0]?.label}</SelectValue>
                   <div className="flex items-center space-x-2">
                     <LuX
                       className="pointer-events-auto h-4 w-4 text-accent-green"
@@ -211,7 +184,7 @@ const TimeSeriesSameLayer: FC<{
                 style={{ width: 'calc(100% - 2rem)' }}
               >
                 <ScrollArea className="max-h-[200px] w-full">
-                  {range.map((r: LayerDateRange) => (
+                  {range?.map((r: LayerDateRange) => (
                     <SelectItem key={r.value} value={r.value} className="px-2">
                       {r?.label}
                     </SelectItem>

--- a/src/components/timeseries-layer/timeline.tsx
+++ b/src/components/timeseries-layer/timeline.tsx
@@ -39,12 +39,12 @@ const Timeline: FC<{
   const date = layers?.[0]?.date;
 
   const currentRange = useMemo(
-    () => range.find((r) => r.value === date) ?? range[0],
+    () => range?.find((r) => r.value === date) ?? range?.[0],
     [date, range]
   );
 
   const currentIndex = useMemo(
-    () => Math.max(0, range.findIndex((r) => r.value === currentRange?.value)),
+    () => Math.max(0, range?.findIndex((r) => r.value === currentRange?.value) ?? 0),
     [range, currentRange]
   );
 
@@ -55,6 +55,7 @@ const Timeline: FC<{
 
   useInterval(
     () => {
+      if (!range?.length) return;
       const nextRange = range[(range.indexOf(currentRange) + 1) % range.length];
       void setLayers([{ ...layers?.[0], date: nextRange.value }]);
     },
@@ -72,7 +73,7 @@ const Timeline: FC<{
 
   const handleSliderChange = useCallback(
     (index: number) => {
-      void setLayers([{ ...layers?.[0], date: range[index].value }]);
+      void setLayers([{ ...layers?.[0], date: range?.[index]?.value }]);
     },
     [layers, setLayers, range]
   );
@@ -81,25 +82,20 @@ const Timeline: FC<{
   const endRangelabel = useMemo(() => range && range[range.length - 1]?.label, [range]);
 
   return (
-    <Tooltip delayDuration={0}>
-      <TooltipTrigger disabled={isCompareActive} asChild>
-        <div className="flex w-full items-center space-x-3 py-3.5">
-          <button
-            type="button"
-            onClick={handleTogglePlay}
-            disabled={isCompareActive}
-            className="pointer-events-auto"
-          >
-            {isPlaying && isActive ? (
-              <LuCirclePause className="h-6 w-6 text-accent-green" />
-            ) : (
-              <LuCirclePlay className="h-6 w-6 text-secondary-500" />
-            )}
-          </button>
+    <div className="flex w-full items-center space-x-3 py-3.5">
+      <button type="button" onClick={handleTogglePlay}>
+        {isPlaying && isActive ? (
+          <LuCirclePause className="h-6 w-6 text-accent-green" />
+        ) : (
+          <LuCirclePlay className="h-6 w-6 text-secondary-500" />
+        )}
+      </button>
+      <Tooltip delayDuration={0}>
+        <TooltipTrigger asChild>
           <div className="relative flex w-full flex-col space-y-2 bg-white-950">
             <div className="max-w flex w-full overflow-hidden">
-              {range.length <= TICK_THRESHOLD ? (
-                range.map((r) => (
+              {(range?.length ?? 0) <= TICK_THRESHOLD ? (
+                range?.map((r) => (
                   <div
                     key={r.value}
                     className={cn('flex w-full items-center justify-center', {
@@ -118,7 +114,7 @@ const Timeline: FC<{
                 <input
                   type="range"
                   min={0}
-                  max={range.length - 1}
+                  max={(range?.length ?? 1) - 1}
                   value={currentIndex}
                   disabled={isCompareActive}
                   onChange={(e) => handleSliderChange(Number(e.target.value))}
@@ -136,30 +132,30 @@ const Timeline: FC<{
               </div>
             </div>
           </div>
-        </div>
-      </TooltipTrigger>
+        </TooltipTrigger>
 
-      <TooltipPortal>
-        <TooltipContent
-          sideOffset={20}
-          side="left"
-          align="center"
-          className={cn({
-            'border-none bg-black-400 text-white-500': true,
-            hidden: !isCompareActive,
-          })}
-        >
-          <div className="max-w-xs text-sm">
-            <p>
-              When the layer comparison functionality is enabled, the timeline is automatically
-              paused .
-            </p>
-            <p>To activate the timeline again, comparison mode must first be disabled.</p>
-          </div>
-          <TooltipArrow />
-        </TooltipContent>
-      </TooltipPortal>
-    </Tooltip>
+        <TooltipPortal>
+          <TooltipContent
+            sideOffset={20}
+            side="left"
+            align="center"
+            className={cn({
+              'border-none bg-black-400 text-white-500': true,
+              hidden: !isCompareActive,
+            })}
+          >
+            <div className="max-w-xs text-sm">
+              <p>
+                When the layer comparison functionality is enabled, the timeline is automatically
+                paused .
+              </p>
+              <p>To activate the timeline again, comparison mode must first be disabled.</p>
+            </div>
+            <TooltipArrow />
+          </TooltipContent>
+        </TooltipPortal>
+      </Tooltip>
+    </div>
   );
 };
 

--- a/src/hooks/geostories.ts
+++ b/src/hooks/geostories.ts
@@ -15,7 +15,7 @@ import API from 'services/api';
  * Example: getGeostoryImageUrl('g1') → '{API_URL}/media/g1.jpg'
  */
 export const getGeostoryImageUrl = (geostoryId: string | number): string =>
-  `${process.env.NEXT_PUBLIC_API_URL}/media/${geostoryId}.jpg`;
+  `${process.env.NEXT_PUBLIC_API_IMAGES_URL}/media/${geostoryId}.jpg`;
 
 export type GeostoriesParams = {
   geostory_id?: string | number;

--- a/src/hooks/map.ts
+++ b/src/hooks/map.ts
@@ -49,7 +49,8 @@ export function usePointData(
         return response.data;
       })
       .catch((error: CanceledError<unknown> | AxiosError) => {
-        console.error('Error fetching region data:', error);
+        if (error instanceof CanceledError) return;
+        throw error;
       });
 
   return useQuery(['region-data', params], fetchRegionData, {


### PR DESCRIPTION
Replace RLayerWMS (single image) with native OL TileLayer<TileWMS> managed imperatively via BufferedTileWMS component. Uses updateParams() for date changes so old tiles stay visible until new ones load, preventing basemap flash during time series playback.

- Swipe control rewritten to accept OL layers directly, auto-centers on visible map area accounting for sidebar width
- Timeline controls unified to use Jotai atom for playback state instead of sessionStorage, with null-safe range access throughout
- Legend overflow fixes: title truncation, responsive max-width
- Dataset card: simplified compare layer toggle logic
