### PR TITLE
doi fix

### DIFF
--- a/src/components/doi-badge/index.tsx
+++ b/src/components/doi-badge/index.tsx
@@ -5,7 +5,10 @@ import { UseCase } from '@/types/monitors-and-geostories';
 const DoiBadge: React.FC<{
   doi: UseCase['doi'][number];
 }> = ({ doi }) => {
-  const d = doi.split('https://doi.org/')[1] || doi;
+  const d = doi.split('https://doi.org/')[1];
+
+  if (!d) return null;
+
   return (
     <Link
       href={doi}

--- a/src/components/globe/geostory-dialog.tsx
+++ b/src/components/globe/geostory-dialog.tsx
@@ -45,6 +45,7 @@ export default function GeostoryDialog({ geostory, open, onOpenChange }: Geostor
 
   const color = getCategoryColor(geostory.theme);
   const firstPublication = geostory.publications?.[0];
+  const publications = geostory.publications || [];
   const useCases = (geostory.use_case_link ?? []).filter((item) => item?.title || item?.url) || [];
   const doi = (geostory.use_case_link ?? []).filter((item) => item?.title || item?.url);
 
@@ -75,7 +76,19 @@ export default function GeostoryDialog({ geostory, open, onOpenChange }: Geostor
           </h3>
 
           {/* Publication link */}
-          {firstPublication?.url && firstPublication?.title && (
+          {!!publications.length &&
+            publications.map((pub, i) => (
+              <a
+                key={i}
+                href={pub.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="hover:text-white truncate text-xs text-white-500 underline"
+              >
+                {pub.title}
+              </a>
+            ))}
+          {/* {firstPublication?.url && firstPublication?.title && (
             <a
               href={firstPublication.url}
               target="_blank"
@@ -84,7 +97,7 @@ export default function GeostoryDialog({ geostory, open, onOpenChange }: Geostor
             >
               {firstPublication.title}
             </a>
-          )}
+          )} */}
 
           {/* Use cases link */}
           {!!useCases.length &&

--- a/src/components/monitors/view/index.tsx
+++ b/src/components/monitors/view/index.tsx
@@ -38,11 +38,12 @@ const MonitorView: FC<MonitorViewProps> = ({ data, geostoryLayers }) => {
         >
           <div className="flex w-full items-center justify-between">
             <h2 className="py-2 font-medium">Datasets</h2>
-            <CollapsibleTrigger
-              className="w-fit p-0 data-[state=open]:bg-transparent"
-              data-testid="collapse-datasets-button"
-            >
-              <Button variant={datasetStatus === 'open' ? 'outline' : 'default'} size="sm">
+            <CollapsibleTrigger asChild data-testid="collapse-datasets-button">
+              <Button
+                variant={datasetStatus === 'open' ? 'outline' : 'default'}
+                size="sm"
+                className="w-fit p-0 data-[state=open]:bg-transparent"
+              >
                 {datasetStatus === 'open' ? 'Collapse' : 'Expand'}
               </Button>
             </CollapsibleTrigger>
@@ -75,11 +76,12 @@ const MonitorView: FC<MonitorViewProps> = ({ data, geostoryLayers }) => {
         >
           <div className="flex w-full items-center justify-between">
             <h2 className="py-2 font-medium">Geostories</h2>
-            <CollapsibleTrigger
-              className="w-fit p-0 data-[state=open]:bg-transparent"
-              data-testid="collapse-geostories-button"
-            >
-              <Button variant={geostoryStatus === 'open' ? 'outline' : 'default'} size="sm">
+            <CollapsibleTrigger asChild data-testid="collapse-geostories-button">
+              <Button
+                variant={geostoryStatus === 'open' ? 'outline' : 'default'}
+                size="sm"
+                className="w-fit p-0 data-[state=open]:bg-transparent"
+              >
                 {geostoryStatus === 'open' ? 'Collapse' : 'Expand'}
               </Button>
             </CollapsibleTrigger>

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -435,7 +435,7 @@ const SidebarContent = forwardRef<HTMLDivElement, ComponentProps<'div'>>(
         ref={ref}
         data-sidebar="content"
         className={cn(
-          'flex min-h-0 flex-1 flex-col gap-2 overflow-auto group-data-[collapsible=icon]:overflow-hidden',
+          'flex min-h-0 flex-1 flex-col gap-2 overflow-auto pr-1 group-data-[collapsible=icon]:overflow-hidden',
           className
         )}
         {...props}


### PR DESCRIPTION
This pull request introduces several improvements to the UI and data handling for Geostory and Monitor views, focusing on better rendering of publication links, improved button accessibility, and minor UI adjustments.

**Geostory publication and use case rendering:**

* Updated the Geostory dialog to display all publication links associated with a geostory, instead of showing only the first publication. Each publication is rendered as a separate link. [[1]](diffhunk://#diff-4c2748a101354a732987b775d5409b9439d739885b5b6bfc999684acb37697c4R48) [[2]](diffhunk://#diff-4c2748a101354a732987b775d5409b9439d739885b5b6bfc999684acb37697c4L78-R91) [[3]](diffhunk://#diff-4c2748a101354a732987b775d5409b9439d739885b5b6bfc999684acb37697c4L87-R100)
* Improved the logic for displaying DOIs in the `DoiBadge` component: now, if the DOI does not match the expected format, the badge is not rendered, preventing invalid output.

**Monitor and Geostory collapsible UI:**

* Refactored the collapsible triggers for Datasets and Geostories sections to use the `asChild` prop, improving accessibility and testability by moving the `data-testid` to the correct element and simplifying the button structure. [[1]](diffhunk://#diff-6ee79c748ed85df7392577975768a281978b145e39501294897e96ab82ad0609L41-L45) [[2]](diffhunk://#diff-6ee79c748ed85df7392577975768a281978b145e39501294897e96ab82ad0609L78-L82)

**UI/UX enhancements:**

* Added right padding (`pr-1`) to the sidebar content for improved spacing and appearance.