### PR TITLE
fix: cap mobile toolbar height so header stays visible

### DIFF
--- a/src/app/(landing)/geostories-mobile.tsx
+++ b/src/app/(landing)/geostories-mobile.tsx
@@ -55,7 +55,7 @@ export const GeostoriesGlobeMobile = () => {
       <DrawerTrigger className="focus:text-white data-[s] group shrink-0 rounded-full border border-accent-green p-3 text-accent-green hover:text-white-500 focus:outline-none active:bg-accent-green data-[state=open]:bg-accent-green data-[state=open]:text-white-500">
         <ListSVG className="h-6 w-6 text-accent-green" />
       </DrawerTrigger>
-      <DrawerContent className="space-y-5 bg-black-500 p-5 text-white-500">
+      <DrawerContent className="max-h-[calc(100dvh-72px)] space-y-5 bg-black-500 p-5 text-white-500">
         <DrawerHeader className="flex flex-row items-center justify-between p-0">
           <DrawerTitle className="inline-flex text-white-500">Geostories</DrawerTitle>
           <DrawerClose className="flex items-center gap-2.5  px-2 py-1 text-sm  focus:outline-none">

--- a/src/app/(landing)/live-updates-mobile.tsx
+++ b/src/app/(landing)/live-updates-mobile.tsx
@@ -21,7 +21,7 @@ export const LiveUpdatesGlobeMobile = () => {
       <DrawerTrigger className="focus:text-white data-[s] group shrink-0 rounded-full border border-accent-green p-3 text-accent-green hover:text-white-500 focus:outline-none active:bg-accent-green data-[state=open]:bg-accent-green data-[state=open]:text-white-500">
         <NewsSVG className="h-6 w-6 text-accent-green" />
       </DrawerTrigger>
-      <DrawerContent className="space-y-5 bg-black-500 p-5 text-white-500">
+      <DrawerContent className="max-h-[calc(100dvh-72px)] space-y-5 bg-black-500 p-5 text-white-500">
         <DrawerHeader className="flex flex-row items-center justify-between p-0">
           <DrawerTitle className="inline-flex text-white-500">
             <p className="font-medium text-white-500">Live feed</p>

--- a/src/containers/explore/toolbar/mobile/nav-bar/index.tsx
+++ b/src/containers/explore/toolbar/mobile/nav-bar/index.tsx
@@ -49,11 +49,11 @@ const MobileExploreNavbar = () => {
   return (
     <div className="fixed bottom-0 left-0 z-50 w-full text-sm">
       <div
-        className="z-50 max-h-[80vh] overflow-auto bg-black-500 text-white-500 transition-transform"
+        className="z-50 max-h-[calc(100dvh-72px)] overflow-auto bg-black-500 text-white-500 transition-transform"
         style={{ transform: isOpen ? 'translateY(0)' : 'translateY(100%)' }}
         onClick={(e) => e.stopPropagation()}
       >
-        <div className={cn('relative p-4', showTheme && 'min-h-[80vh]')}>
+        <div className={cn('relative p-4', showTheme && 'min-h-[calc(100dvh-72px)]')}>
           <div
             className={cn(
               'absolute inset-0 overflow-hidden transition-all duration-300 ease-in-out',


### PR DESCRIPTION
Mobile explore navbar and landing globe drawers used max-h-[80vh], which on short viewports overlapped the fixed header. Cap height to calc(100dvh-72px) so the panel always leaves room for the header.
