### PR TITLE
test: bump no-results search assertion timeout to 30s

### DIFF
--- a/e2e/search.spec.ts
+++ b/e2e/search.spec.ts
@@ -79,10 +79,10 @@ test.describe('featured geostories on landing page', () => {
     const searchInput = page.getByTestId('search-input');
     await searchInput.fill('zzz_no_match_query_xyz');
 
-    // The search is debounced by 500ms then hits the real API on CI — allow 10s for the
-    // request to return and the empty-state element to render.
+    // The search is debounced by 500ms then hits the real API on CI. Slow runners can
+    // take well over 10s for the round-trip, so use 30s — still inside the 60s test budget.
     const noResults = page.getByTestId('no-geostories-found');
-    await expect(noResults).toBeVisible({ timeout: 10000 });
+    await expect(noResults).toBeVisible({ timeout: 30000 });
     await expect(noResults).toContainText(
       "We couldn't find any geostories for your search. Try different keywords or remove some filters."
     );


### PR DESCRIPTION
## Summary
- The `shows no-results message when search yields no featured geostories` test waits 10s for the empty-state element to render, but on slow CI runners the 500ms debounce plus the real `/geostories` round-trip can exceed that.
- Bump the locator timeout to 30s, matching the surrounding 60s test budget. Logic unchanged.

## Test plan
- [ ] `yarn test e2e/search.spec.ts` passes locally.
- [ ] CI run on this PR is green.