### PR TITLE
fix: handle map tooltip across layer and regions state changes

### DIFF
--- a/e2e/explore-theme-filter.spec.ts
+++ b/e2e/explore-theme-filter.spec.ts
@@ -1,0 +1,129 @@
+import { test, expect, type Page } from '@playwright/test';
+
+import type { MonitorsAndGeostories } from '@/types/monitors-and-geostories';
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL;
+
+async function fetchAllItems(page: Page): Promise<MonitorsAndGeostories> {
+  if (!API_URL) throw new Error('NEXT_PUBLIC_API_URL is not set');
+  const response = await page.request.get(`${API_URL}/monitors-and-geostories/`);
+  if (!response.ok()) throw new Error(`Failed to fetch items: ${response.status()}`);
+  return response.json();
+}
+
+async function fetchItemsByTheme(page: Page, theme: string): Promise<MonitorsAndGeostories> {
+  if (!API_URL) throw new Error('NEXT_PUBLIC_API_URL is not set');
+  const response = await page.request.get(
+    `${API_URL}/monitors-and-geostories/?theme=${encodeURIComponent(theme)}`
+  );
+  if (!response.ok()) throw new Error(`Failed to fetch items: ${response.status()}`);
+  return response.json();
+}
+
+test.describe('explore page — map sidebar theme filter', () => {
+  test.describe.configure({ timeout: 60_000 });
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/explore', { waitUntil: 'load' });
+    // Wait for first dataset render so the sidebar is interactive.
+    await page
+      .getByTestId('results-count-number')
+      .waitFor({ state: 'attached', timeout: 30_000 });
+  });
+
+  test('All Categories button is rendered, labeled, and active by default', async ({ page }) => {
+    const allBtn = page.getByTestId('map-sidebar-category-All');
+    await expect(allBtn).toBeVisible();
+    await expect(allBtn).toHaveAttribute('aria-label', 'All Categories');
+    await expect(allBtn).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  test('clicking All Categories shows every dataset (bug regression)', async ({ page }) => {
+    const all = await fetchAllItems(page);
+
+    // First narrow the list with a real category.
+    await page.getByTestId('map-sidebar-category-Forest').click();
+    await expect(page).toHaveURL(/categories=.*Forest/);
+    await expect(page.getByTestId('map-sidebar-category-Forest')).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+
+    // Then click "All Categories" — full list must come back.
+    const allBtn = page.getByTestId('map-sidebar-category-All');
+    await allBtn.click();
+
+    await expect(allBtn).toHaveAttribute('aria-pressed', 'true');
+    await expect(page.getByTestId('results-count-number')).toHaveText(String(all.length));
+    // URL should not encode an array like ["All"] — value is the string "All" or absent.
+    const param = new URL(page.url()).searchParams.get('categories');
+    expect(param ?? '"All"').not.toMatch(/\[/);
+  });
+
+  test('selecting a category narrows results to that theme', async ({ page }) => {
+    const theme = 'Forest';
+    const expected = await fetchItemsByTheme(page, theme);
+
+    const btn = page.getByTestId(`map-sidebar-category-${theme}`);
+    await btn.click();
+    await expect(btn).toHaveAttribute('aria-pressed', 'true');
+    await expect(page).toHaveURL(new RegExp(`categories=.*${encodeURIComponent(theme)}`));
+    await expect(page.getByTestId('results-count-number')).toHaveText(String(expected.length));
+
+    // Only one category active at a time in the map sidebar.
+    await expect(page.getByTestId('map-sidebar-category-All')).toHaveAttribute(
+      'aria-pressed',
+      'false'
+    );
+  });
+
+  test('each category button is keyboard reachable and activates with Enter', async ({ page }) => {
+    const forest = page.getByTestId('map-sidebar-category-Forest');
+    await forest.focus();
+    await expect(forest).toBeFocused();
+    await page.keyboard.press('Enter');
+    await expect(forest).toHaveAttribute('aria-pressed', 'true');
+
+    const all = page.getByTestId('map-sidebar-category-All');
+    await all.focus();
+    await page.keyboard.press('Space');
+    await expect(all).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  test('every category button exposes a programmatic accessible name', async ({ page }) => {
+    const labels = [
+      ['All', 'All Categories'],
+      ['Agriculture', 'Agriculture'],
+      ['Water', 'Water'],
+      ['Climate & Health', 'Climate & Health'],
+      ['Soil', 'Soil'],
+      ['Forest', 'Forest'],
+      ['Biodiversity', 'Biodiversity'],
+    ] as const;
+
+    for (const [id, label] of labels) {
+      const btn = page.getByTestId(`map-sidebar-category-${id}`);
+      await expect(btn).toBeVisible();
+      await expect(btn).toHaveAttribute('aria-label', label);
+      // Toggle semantics: must always expose aria-pressed.
+      await expect(btn).toHaveAttribute('aria-pressed', /(true|false)/);
+    }
+  });
+
+  test('hit target is at least 44x44 (WCAG 2.5.5 Enhanced)', async ({ page }) => {
+    const btn = page.getByTestId('map-sidebar-category-All');
+    const box = await btn.evaluate((el) => {
+      const cs = window.getComputedStyle(el, '::before');
+      const rect = el.getBoundingClientRect();
+      // Extension via the ::before pseudo-element.
+      const extendTop = Math.abs(parseFloat(cs.top || '0'));
+      const extendLeft = Math.abs(parseFloat(cs.left || '0'));
+      return {
+        width: rect.width + 2 * extendLeft,
+        height: rect.height + 2 * extendTop,
+      };
+    });
+    expect(box.width).toBeGreaterThanOrEqual(44);
+    expect(box.height).toBeGreaterThanOrEqual(44);
+  });
+});

--- a/e2e/map.spec.ts
+++ b/e2e/map.spec.ts
@@ -303,5 +303,12 @@ test.describe('map tooltip', () => {
       'Show point histogram'
     );
     await expect(page.getByTestId('map-tooltip-region-histogram')).toHaveCount(0);
+
+    // Point queries can't be named — show coordinates so the user knows where
+    // they clicked. Expect "lat°, lon°" with at least one decimal place each.
+    const coords = page.getByTestId('map-tooltip-coordinates');
+    await expect(coords).toBeVisible();
+    await expect(coords).toContainText('Coordinates:');
+    await expect(coords).toContainText(/-?\d+\.\d+°,\s*-?\d+\.\d+°/);
   });
 });

--- a/e2e/map.spec.ts
+++ b/e2e/map.spec.ts
@@ -211,3 +211,97 @@ test.describe('general information in map page', () => {
     await expect(privacyPolicy).toHaveAttribute('href', 'https://earthmonitor.org/privacy-policy/');
   });
 });
+
+test.describe('map tooltip', () => {
+  test('shows "No layer active" message when clicking the map with no layer', async ({
+    page,
+  }) => {
+    await mockAPIs(page);
+    await page.goto('/explore/monitor/m1', { waitUntil: 'networkidle' });
+
+    const viewport = page.locator('.ol-viewport').first();
+    await expect(viewport).toBeVisible();
+    const box = await viewport.boundingBox();
+    if (!box) throw new Error('map viewport not laid out');
+    // Click well inside the map, far enough from the sidebar to avoid pointer-event interception.
+    await page.mouse.click(box.x + box.width - 100, box.y + box.height / 2);
+
+    const tooltip = page.getByTestId('map-tooltip');
+    await expect(tooltip).toBeVisible();
+    await expect(page.getByTestId('map-tooltip-title')).toHaveText('No layer active');
+    await expect(page.getByTestId('map-tooltip-no-layer')).toBeVisible();
+    await expect(page.getByTestId('map-tooltip-point-histogram')).toHaveCount(0);
+    await expect(page.getByTestId('map-tooltip-region-histogram')).toHaveCount(0);
+
+    await page.getByTestId('map-tooltip-close').click();
+    await expect(tooltip).toHaveCount(0);
+  });
+
+  test('closes the tooltip on Escape and exposes dialog semantics', async ({ page }) => {
+    await mockAPIs(page);
+    await page.goto('/explore/monitor/m1', { waitUntil: 'networkidle' });
+
+    const viewport = page.locator('.ol-viewport').first();
+    await expect(viewport).toBeVisible();
+    const box = await viewport.boundingBox();
+    if (!box) throw new Error('map viewport not laid out');
+    await page.mouse.click(box.x + box.width - 100, box.y + box.height / 2);
+
+    const tooltip = page.getByTestId('map-tooltip');
+    await expect(tooltip).toBeVisible();
+    await expect(tooltip).toHaveAttribute('role', 'dialog');
+    await expect(tooltip).toHaveAttribute('aria-live', 'polite');
+    await expect(page.getByTestId('map-tooltip-close')).toBeFocused();
+
+    await page.keyboard.press('Escape');
+    await expect(tooltip).toHaveCount(0);
+  });
+
+  test('shows point histogram button when clicking the map with an active layer', async ({
+    page,
+  }) => {
+    // Mock GetFeatureInfo for the WMS layer so a numeric value is returned.
+    await page.route(
+      /geoserver\.earthmonitor\.org\/geoserver\/.*REQUEST=GetFeatureInfo/i,
+      (route) =>
+        route.fulfill({
+          contentType: 'application/json',
+          body: JSON.stringify({
+            type: 'FeatureCollection',
+            features: [{ type: 'Feature', properties: { value: 42 } }],
+          }),
+        })
+    );
+
+    // Override the layer fixture so the GFI request fires (needs gs_name + gs_base_wms).
+    const layerWithWms = {
+      ...LAYER_L1,
+      gs_name: 'oem:landcover',
+      gs_base_wms: 'https://geoserver.earthmonitor.org/geoserver/oem/wms',
+    };
+    await mockAPIs(page);
+    await page.route(new RegExp(`${API_URL}/layers`), (route) =>
+      route.fulfill({ json: [layerWithWms] })
+    );
+    await page.route(new RegExp(`${API_URL}/monitors/m1/layers`), (route) =>
+      route.fulfill({ json: [layerWithWms] })
+    );
+
+    await page.goto(LAYER_URL, { waitUntil: 'networkidle' });
+
+    const viewport = page.locator('.ol-viewport').first();
+    await expect(viewport).toBeVisible();
+    const box = await viewport.boundingBox();
+    if (!box) throw new Error('map viewport not laid out');
+    // Click well inside the map, far enough from the sidebar to avoid pointer-event interception.
+    await page.mouse.click(box.x + box.width - 100, box.y + box.height / 2);
+
+    const tooltip = page.getByTestId('map-tooltip');
+    await expect(tooltip).toBeVisible();
+    await expect(page.getByTestId('map-tooltip-title')).toContainText('Land Cover 2000');
+    await expect(page.getByTestId('map-tooltip-point-histogram')).toHaveText(
+      'Show point histogram'
+    );
+    await expect(page.getByTestId('map-tooltip-region-histogram')).toHaveCount(0);
+  });
+});

--- a/e2e/mobile-drawer.spec.ts
+++ b/e2e/mobile-drawer.spec.ts
@@ -1,0 +1,128 @@
+import { test, expect, devices, type Page } from '@playwright/test';
+
+const VIEWPORTS = [
+  { name: 'iPhone SE', ...devices['iPhone SE'] },
+  { name: 'iPhone 14 Pro', ...devices['iPhone 14 Pro'] },
+  { name: 'Pixel 7', ...devices['Pixel 7'] },
+  { name: 'tablet', viewport: { width: 768, height: 1024 } },
+  { name: 'small laptop (< xl)', viewport: { width: 1100, height: 800 } },
+];
+
+async function waitForLandingReady(page: Page) {
+  // Mobile landing renders only the globe + drawer triggers — no
+  // `featured-geostories-count`. Wait on the trigger we're about to click.
+  await page
+    .getByTestId('mobile-geostories-trigger')
+    .waitFor({ state: 'visible', timeout: 30000 });
+}
+
+type Rect = { top: number; bottom: number; height: number };
+
+async function rectOf(page: Page, testId: string): Promise<Rect> {
+  return page.getByTestId(testId).evaluate((el) => {
+    const r = el.getBoundingClientRect();
+    return { top: r.top, bottom: r.bottom, height: r.height };
+  });
+}
+
+/** Wait for vaul's slide-up animation to settle, i.e. the rect stops moving. */
+async function waitForRectToSettle(page: Page, testId: string) {
+  await expect
+    .poll(
+      async () => {
+        const a = await rectOf(page, testId);
+        await page.waitForTimeout(80);
+        const b = await rectOf(page, testId);
+        return Math.abs(a.top - b.top) + Math.abs(a.bottom - b.bottom);
+      },
+      { timeout: 5000, intervals: [100, 150, 200] }
+    )
+    .toBeLessThan(0.5);
+}
+
+test.describe('landing — mobile drawer height', () => {
+  test.describe.configure({ timeout: 60_000 });
+
+  for (const v of VIEWPORTS) {
+    test(`geostories drawer opens below the header (${v.name})`, async ({ browser }) => {
+      const context = await browser.newContext({
+        viewport: v.viewport,
+        userAgent: v.userAgent,
+        deviceScaleFactor: v.deviceScaleFactor,
+        isMobile: v.isMobile,
+        hasTouch: v.hasTouch,
+      });
+      const page = await context.newPage();
+      await page.goto('/', { waitUntil: 'load' });
+      await waitForLandingReady(page);
+
+      const headerBox = await page.locator('header').first().evaluate((el) =>
+        el.getBoundingClientRect().toJSON()
+      );
+
+      const trigger = page.getByTestId('mobile-geostories-trigger');
+      await expect(trigger).toBeVisible();
+      await trigger.click();
+
+      const drawer = page.getByTestId('mobile-geostories-drawer');
+      await expect(drawer).toBeVisible();
+      await waitForRectToSettle(page, 'mobile-geostories-drawer');
+
+      // Measure the visible drawer-header (top of the content the user sees)
+      // rather than the outer drawer wrapper — vaul may inflate the wrapper's
+      // box past the visible top.
+      const visibleTopBox = await drawer.locator('[data-slot="drawer-header"]').evaluate((el) =>
+        el.getBoundingClientRect().toJSON()
+      );
+
+      // Drawer's visible top edge must sit at or below the header's bottom.
+      expect(visibleTopBox.top).toBeGreaterThanOrEqual(headerBox.bottom);
+
+      await context.close();
+    });
+  }
+
+  test('live updates drawer opens below the header', async ({ browser }) => {
+    const context = await browser.newContext({ ...devices['iPhone 14 Pro'] });
+    const page = await context.newPage();
+    await page.goto('/', { waitUntil: 'load' });
+    await waitForLandingReady(page);
+
+    const headerBox = await page.locator('header').first().evaluate((el) =>
+      el.getBoundingClientRect().toJSON()
+    );
+
+    const trigger = page.getByTestId('mobile-live-updates-trigger');
+    await expect(trigger).toBeVisible();
+    await trigger.click();
+
+    const drawer = page.getByTestId('mobile-live-updates-drawer');
+    await expect(drawer).toBeVisible();
+    await waitForRectToSettle(page, 'mobile-live-updates-drawer');
+
+    const visibleTopBox = await drawer.locator('[data-slot="drawer-header"]').evaluate((el) =>
+      el.getBoundingClientRect().toJSON()
+    );
+    expect(visibleTopBox.top).toBeGreaterThanOrEqual(headerBox.bottom);
+
+    await context.close();
+  });
+
+  test('both mobile drawer triggers expose an accessible name', async ({ browser }) => {
+    const context = await browser.newContext({ ...devices['iPhone 14 Pro'] });
+    const page = await context.newPage();
+    await page.goto('/', { waitUntil: 'load' });
+    await waitForLandingReady(page);
+
+    await expect(page.getByTestId('mobile-geostories-trigger')).toHaveAttribute(
+      'aria-label',
+      'Open geostories list'
+    );
+    await expect(page.getByTestId('mobile-live-updates-trigger')).toHaveAttribute(
+      'aria-label',
+      'Open live updates feed'
+    );
+
+    await context.close();
+  });
+});

--- a/e2e/mobile-drawer.spec.ts
+++ b/e2e/mobile-drawer.spec.ts
@@ -1,11 +1,13 @@
-import { test, expect, devices, type Page } from '@playwright/test';
+import { test, expect, devices, type BrowserContextOptions, type Page } from '@playwright/test';
 
-const VIEWPORTS = [
-  { name: 'iPhone SE', ...devices['iPhone SE'] },
-  { name: 'iPhone 14 Pro', ...devices['iPhone 14 Pro'] },
-  { name: 'Pixel 7', ...devices['Pixel 7'] },
-  { name: 'tablet', viewport: { width: 768, height: 1024 } },
-  { name: 'small laptop (< xl)', viewport: { width: 1100, height: 800 } },
+type ViewportCase = { name: string; context: BrowserContextOptions };
+
+const VIEWPORTS: ViewportCase[] = [
+  { name: 'iPhone SE', context: devices['iPhone SE'] },
+  { name: 'iPhone 14 Pro', context: devices['iPhone 14 Pro'] },
+  { name: 'Pixel 7', context: devices['Pixel 7'] },
+  { name: 'tablet', context: { viewport: { width: 768, height: 1024 } } },
+  { name: 'small laptop (< xl)', context: { viewport: { width: 1100, height: 800 } } },
 ];
 
 async function waitForLandingReady(page: Page) {
@@ -45,13 +47,7 @@ test.describe('landing — mobile drawer height', () => {
 
   for (const v of VIEWPORTS) {
     test(`geostories drawer opens below the header (${v.name})`, async ({ browser }) => {
-      const context = await browser.newContext({
-        viewport: v.viewport,
-        userAgent: v.userAgent,
-        deviceScaleFactor: v.deviceScaleFactor,
-        isMobile: v.isMobile,
-        hasTouch: v.hasTouch,
-      });
+      const context = await browser.newContext(v.context);
       const page = await context.newPage();
       await page.goto('/', { waitUntil: 'load' });
       await waitForLandingReady(page);

--- a/src/app/(landing)/geostories-mobile.tsx
+++ b/src/app/(landing)/geostories-mobile.tsx
@@ -52,10 +52,17 @@ export const GeostoriesGlobeMobile = () => {
   });
   return (
     <Drawer>
-      <DrawerTrigger className="focus:text-white data-[s] group shrink-0 rounded-full border border-accent-green p-3 text-accent-green hover:text-white-500 focus:outline-none active:bg-accent-green data-[state=open]:bg-accent-green data-[state=open]:text-white-500">
+      <DrawerTrigger
+        aria-label="Open geostories list"
+        data-testid="mobile-geostories-trigger"
+        className="focus:text-white data-[s] group shrink-0 rounded-full border border-accent-green p-3 text-accent-green hover:text-white-500 focus:outline-none active:bg-accent-green data-[state=open]:bg-accent-green data-[state=open]:text-white-500"
+      >
         <ListSVG className="h-6 w-6 text-accent-green" />
       </DrawerTrigger>
-      <DrawerContent className="max-h-[calc(100dvh-72px)] space-y-5 bg-black-500 p-5 text-white-500">
+      <DrawerContent
+        data-testid="mobile-geostories-drawer"
+        className="max-h-[calc(100dvh-80px)] space-y-5 bg-black-500 p-5 text-white-500 sm:max-h-[calc(100dvh-100px)]"
+      >
         <DrawerHeader className="flex flex-row items-center justify-between p-0">
           <DrawerTitle className="inline-flex text-white-500">Geostories</DrawerTitle>
           <DrawerClose className="flex items-center gap-2.5  px-2 py-1 text-sm  focus:outline-none">

--- a/src/app/(landing)/live-updates-mobile.tsx
+++ b/src/app/(landing)/live-updates-mobile.tsx
@@ -18,10 +18,17 @@ import { NewsSVG } from '@/SVGS/news';
 export const LiveUpdatesGlobeMobile = () => {
   return (
     <Drawer>
-      <DrawerTrigger className="focus:text-white data-[s] group shrink-0 rounded-full border border-accent-green p-3 text-accent-green hover:text-white-500 focus:outline-none active:bg-accent-green data-[state=open]:bg-accent-green data-[state=open]:text-white-500">
+      <DrawerTrigger
+        aria-label="Open live updates feed"
+        data-testid="mobile-live-updates-trigger"
+        className="focus:text-white data-[s] group shrink-0 rounded-full border border-accent-green p-3 text-accent-green hover:text-white-500 focus:outline-none active:bg-accent-green data-[state=open]:bg-accent-green data-[state=open]:text-white-500"
+      >
         <NewsSVG className="h-6 w-6 text-accent-green" />
       </DrawerTrigger>
-      <DrawerContent className="max-h-[calc(100dvh-72px)] space-y-5 bg-black-500 p-5 text-white-500">
+      <DrawerContent
+        data-testid="mobile-live-updates-drawer"
+        className="max-h-[calc(100dvh-80px)] space-y-5 bg-black-500 p-5 text-white-500 sm:max-h-[calc(100dvh-100px)]"
+      >
         <DrawerHeader className="flex flex-row items-center justify-between p-0">
           <DrawerTitle className="inline-flex text-white-500">
             <p className="font-medium text-white-500">Live feed</p>

--- a/src/components/datasets/card/index.tsx
+++ b/src/components/datasets/card/index.tsx
@@ -1,12 +1,14 @@
 'use client';
 
-import { FC, useCallback, useEffect, useMemo, useRef } from 'react';
+import { FC, useCallback, useEffect, useMemo } from 'react';
 
 import { useAtom } from 'jotai';
 
 import { Geostory } from '@/types/geostories';
 import type { LayerParsed } from '@/types/layers';
 import { Monitor, MonitorParsed } from '@/types/monitors';
+
+import { scrollToHistogram } from '@/lib/scroll-to-histogram';
 
 import { histogramVisibilityAtom } from '@/app/store';
 
@@ -42,7 +44,6 @@ const DatasetCard: FC<DatasetCardProps> = ({
   const hasCompare = !!compareLayers?.[0]?.id;
 
   const [isHistogramActive] = useAtom(histogramVisibilityAtom);
-  const cardRef = useRef<HTMLDivElement>(null);
 
   const handleToggleLayer = useCallback(() => {
     if (!isActive) {
@@ -83,15 +84,12 @@ const DatasetCard: FC<DatasetCardProps> = ({
   ]);
 
   useEffect(() => {
-    if (!isHistogramActive || !isActive || !cardRef.current) return;
-    requestAnimationFrame(() => {
-      cardRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
-    });
-  }, [isHistogramActive, isActive]);
+    if (!isHistogramActive || !isActive || !id) return;
+    requestAnimationFrame(() => scrollToHistogram(id));
+  }, [isHistogramActive, isActive, id]);
 
   return (
     <div
-      ref={cardRef}
       id={`histogram-anchor-${id}`}
       className="space-y-3 rounded-3xl border border-black-100 p-3.5 text-sm font-medium text-white-50"
       data-testid={`dataset-item-${id}`}

--- a/src/components/map/index.tsx
+++ b/src/components/map/index.tsx
@@ -20,6 +20,7 @@ import { fetchFeatureInfo, getFeatureInfoUrl, firstPropertyValue } from '@/lib/w
 
 import {
   coordinateAtom,
+  histogramVisibilityAtom,
   lonLatAtom,
   nutsDataParamsAtom,
   nutsDataParamsCompareAtom,
@@ -83,6 +84,8 @@ const Map: FC<CustomMapProps> = ({ initialViewState = DEFAULT_VIEWPORT }) => {
 
   const setNutsDataResponse = useSetAtom(nutsDataResponseAtom);
   const setCompareNutsProperties = useSetAtom(nutsDataResponseCompareAtom);
+
+  const setHistogramVisibility = useSetAtom(histogramVisibilityAtom);
 
   const setPlaying = useSetAtom(timeSeriesPlaybackAtom);
 
@@ -347,8 +350,52 @@ const Map: FC<CustomMapProps> = ({ initialViewState = DEFAULT_VIEWPORT }) => {
   }, [dataBbox, setBbox]);
 
   useEffect(() => {
-    setTooltipInfo((prev) => ({ ...prev, position: null }));
-  }, [layerId, compareLayerId]);
+    if (!isLayerActive) {
+      setHistogramVisibility(false);
+      setNutsDataParams(NUTS_INITIAL_STATE);
+      setNutsDataParamsCompare(NUTS_INITIAL_STATE);
+    }
+  }, [isLayerActive, setHistogramVisibility, setNutsDataParams, setNutsDataParamsCompare]);
+
+  useEffect(() => {
+    if (!isRegionsLayerActive) return;
+    setNutsDataParams((prev) =>
+      prev?.NUTS_ID && prev.LAYER_ID !== layerId ? { ...prev, LAYER_ID: layerId } : prev
+    );
+  }, [layerId, isRegionsLayerActive, setNutsDataParams]);
+
+  useEffect(() => {
+    if (!isRegionsLayerActive) return;
+    if (!tooltipInfo.coordinate || !layerId || !mapRef.current) return;
+    const resolution = mapRef.current.ol.getView?.()?.getResolution?.();
+    if (!resolution) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const res = await getHistogramData(
+          wmsNutsSource,
+          tooltipInfo.coordinate,
+          resolution,
+          layerId
+        );
+        if (cancelled) return;
+        if (res?.nutsDataParams?.NUTS_ID) {
+          setNutsDataParams(res.nutsDataParams);
+        }
+      } catch (err) {
+        console.error(err);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    isRegionsLayerActive,
+    tooltipInfo.coordinate,
+    layerId,
+    wmsNutsSource,
+    setNutsDataParams,
+  ]);
 
   // activates timeseries and comparative mode if geostory is comparative and just the first time
   // after that, the user should manage timeseries and comparative mode
@@ -545,18 +592,15 @@ const Map: FC<CustomMapProps> = ({ initialViewState = DEFAULT_VIEWPORT }) => {
         <Attributions className="absolute bottom-0 z-40 sm:left-auto sm:right-3 lg:bottom-3 lg:left-[620px]" />
       </RMap>
 
-      {/* Interactivity */}
-      {dataMeta && (
-        <MapTooltip
-          {...tooltipInfo}
-          data={
-            tooltipSide === 'right' && isCompareLayerActive
-              ? tooltipInfo.rightData
-              : tooltipInfo.leftData
-          }
-          onCloseTooltip={handleCloseTooltip}
-        />
-      )}
+      <MapTooltip
+        {...tooltipInfo}
+        data={
+          tooltipSide === 'right' && isCompareLayerActive
+            ? tooltipInfo.rightData
+            : tooltipInfo.leftData
+        }
+        onCloseTooltip={handleCloseTooltip}
+      />
     </div>
   );
 };

--- a/src/components/map/stats/point-histogram.tsx
+++ b/src/components/map/stats/point-histogram.tsx
@@ -1,12 +1,13 @@
 'use client';
 
-import { FC, useCallback, useMemo } from 'react';
+import { FC, useCallback, useEffect, useMemo, useRef } from 'react';
 
 import { format } from 'd3-format';
 import { useAtomValue, useSetAtom } from 'jotai';
 import { FiDownload } from 'react-icons/fi';
 
 import { cn } from '@/lib/classnames';
+import { scrollToHistogram } from '@/lib/scroll-to-histogram';
 
 import { histogramVisibilityAtom, lonLatAtom } from '@/app/store';
 
@@ -89,6 +90,18 @@ const PointHistogram: FC<GeostoryTooltipInfo> = ({ title, color, id }: GeostoryT
 
   const handleCloseAnalysis = () => setHistogramVisibility(false);
 
+  // Reveal the histogram card when an error is rendered for a new
+  // location — without this, the inline error can land below the
+  // current scroll position and the user thinks nothing happened.
+  const lastScrolledErrorKey = useRef<string | null>(null);
+  useEffect(() => {
+    if (!histogramError || !id || !lonLat) return;
+    const key = `${id}:${lonLat[0]}:${lonLat[1]}`;
+    if (lastScrolledErrorKey.current === key) return;
+    lastScrolledErrorKey.current = key;
+    requestAnimationFrame(() => scrollToHistogram(id));
+  }, [histogramError, id, lonLat]);
+
   return (
     <div className="relative space-y-2">
       <div className="space-y-3 font-satoshi font-bold">
@@ -121,7 +134,11 @@ const PointHistogram: FC<GeostoryTooltipInfo> = ({ title, color, id }: GeostoryT
         </div>
         {isLoadingHistogram && <Loading />}
         {!isLoadingHistogram && histogramError && (
-          <p className="text-alert-error text-sm">
+          <p
+            data-testid="point-histogram-error"
+            role="alert"
+            className="text-alert-error text-sm"
+          >
             Error occurred while fetching the data:{' '}
             {(histogramError.response?.data as { message?: string })?.message ||
               histogramError.message}

--- a/src/components/map/tooltip/index.tsx
+++ b/src/components/map/tooltip/index.tsx
@@ -1,8 +1,16 @@
 'use client';
 
-import { FC, useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import {
+  FC,
+  useCallback,
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 
-import { format } from 'd3-format';
 import { useAtom, useSetAtom, useAtomValue } from 'jotai';
 import { LuX } from 'react-icons/lu';
 
@@ -21,8 +29,6 @@ import type { MonitorTooltipInfo } from '@/components/map/types';
 import { Button } from '@/components/ui/button';
 
 import { AnalysisSVG } from '@/SVGS/analysis';
-
-const numberFormat = format(',.2f');
 
 interface TooltipProps extends MonitorTooltipInfo {
   onCloseTooltip: () => void;
@@ -76,7 +82,28 @@ const MapTooltip: FC<MapTooltipProps> = ({ position, onCloseTooltip = () => null
   }, [layerData?.theme]);
 
   const ref = useRef<HTMLDivElement>(null);
+  const closeRef = useRef<HTMLButtonElement>(null);
+  const titleId = useId();
+  const bodyId = useId();
   const [coords, setCoords] = useState<{ left: number; top: number } | null>(null);
+  const [tailOnTop, setTailOnTop] = useState(false);
+
+  useEffect(() => {
+    if (!position) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation();
+        onCloseTooltip();
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [position, onCloseTooltip]);
+
+  useEffect(() => {
+    if (!position || !coords) return;
+    closeRef.current?.focus({ preventScroll: true });
+  }, [position, coords]);
 
   useLayoutEffect(() => {
     if (!position || !ref.current) return;
@@ -87,90 +114,125 @@ const MapTooltip: FC<MapTooltipProps> = ({ position, onCloseTooltip = () => null
     const w = el.offsetWidth;
     const h = el.offsetHeight;
     const margin = 8;
-    const gap = 10;
+    const gap = 14;
 
     let left = position[0] - w / 2;
     let top = position[1] - gap - h;
+    let flipped = false;
 
-    if (top < margin) top = position[1] + gap;
+    if (top < margin) {
+      top = position[1] + gap;
+      flipped = true;
+    }
 
     left = Math.max(margin, Math.min(left, pw - w - margin));
     top = Math.max(margin, Math.min(top, ph - h - margin));
 
     setCoords((prev) => (prev?.left === left && prev?.top === top ? prev : { left, top }));
+    setTailOnTop((prev) => (prev === flipped ? prev : flipped));
   });
 
   if (!position) return null;
 
   const hasLayer = !!data?.id;
   const hasValue = data?.value !== null && data?.value !== undefined && data?.value !== 0;
-  const label = [nutsDataResponse?.NUTS_NAME, countryName].filter(Boolean).join(', ');
+  const label = [countryName, nutsDataResponse?.NUTS_NAME].filter(Boolean).join(', ');
 
   return (
     <div
       ref={ref}
-      className="absolute z-50 min-w-[250px] max-w-[320px] rounded-[20px] bg-black-150 p-5 font-satoshi font-medium text-white-500 shadow-md"
+      data-testid="map-tooltip"
+      role="dialog"
+      aria-modal="false"
+      aria-labelledby={titleId}
+      aria-describedby={bodyId}
+      aria-live="polite"
+      className="absolute z-50 w-[263px] font-satoshi font-medium text-white-500"
       style={{
         left: `${coords?.left ?? position[0]}px`,
         top: `${coords?.top ?? position[1] - 10}px`,
         visibility: coords ? 'visible' : 'hidden',
       }}
     >
-      <div className="space-y-5">
-        <div className="flex w-full items-start justify-between space-x-2">
-          <AnalysisSVG className="h-6 w-6 flex-shrink-0" />
-          <h3 style={{ color }} className="break-word flex max-w-[300px] flex-wrap  text-left ">
-            {hasLayer ? data.title : 'No layer active'}
-          </h3>
+      <div className="relative rounded-[20px] bg-black-150 p-5 shadow-md">
+        <button
+          ref={closeRef}
+          type="button"
+          data-testid="map-tooltip-close"
+          onClick={onCloseTooltip}
+          aria-label="Close tooltip"
+          className="size-[34px] absolute -right-2 -top-2 z-10 flex items-center justify-center rounded-full border border-white-800 bg-black-150 text-white-500 transition-colors hover:border-white-500 hover:text-white-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white-500 focus-visible:ring-offset-2 focus-visible:ring-offset-black-150"
+        >
+          <LuX aria-hidden="true" focusable="false" className="size-4" />
+        </button>
 
-          <button type="button" onClick={onCloseTooltip}>
-            <LuX className="h-6 w-6" />
-          </button>
+        <div id={bodyId} className="flex flex-col gap-3">
+          <div className="flex items-start gap-1 pr-7">
+            <AnalysisSVG aria-hidden="true" className="size-6 flex-shrink-0" />
+            <h3
+              id={titleId}
+              data-testid="map-tooltip-title"
+              style={{ color }}
+              className="text-xs leading-[1.4]"
+            >
+              {hasLayer ? data.title : 'No layer active'}
+            </h3>
+          </div>
+
+          {!hasLayer && (
+            <p data-testid="map-tooltip-no-layer" className="text-xs">
+              Activate at least one layer from the sidebar to see data for this location.
+            </p>
+          )}
+
+          {hasLayer && hasValue && isRegionsLayerActive && (
+            <p className="flex items-center gap-3 text-xs">
+              <span className="whitespace-nowrap">Location Selected:</span>
+              {!!nutsDataResponse?.NUTS_NAME && (
+                <span
+                  data-testid="map-tooltip-location"
+                  className="whitespace-nowrap rounded-full bg-white-950 px-2 py-0.5"
+                >
+                  {label}
+                </span>
+              )}
+            </p>
+          )}
+
+          {hasLayer && !hasValue && (
+            <p data-testid="map-tooltip-no-data" className="text-xs">
+              No data is available at this specific location.
+            </p>
+          )}
+
+          {hasLayer && hasValue && !isRegionsLayerActive && (
+            <Button
+              data-testid="map-tooltip-point-histogram"
+              variant="outline"
+              onClick={handleClick}
+              className="h-[47px] w-full justify-center px-[14px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white-500 focus-visible:ring-offset-2 focus-visible:ring-offset-black-150"
+            >
+              Show point histogram
+            </Button>
+          )}
+          {hasLayer && hasValue && isRegionsLayerActive && (
+            <Button
+              data-testid="map-tooltip-region-histogram"
+              variant="outline"
+              onClick={handleHistogram}
+              className="h-[47px] w-full justify-center px-[14px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white-500 focus-visible:ring-offset-2 focus-visible:ring-offset-black-150"
+            >
+              Show region histogram
+            </Button>
+          )}
         </div>
 
-        {!hasLayer && (
-          <span>
-            Activate at least one layer from the sidebar to see data for this location.
-          </span>
-        )}
-
-        {hasLayer && hasValue && (
-          <>
-            <div className="flex items-center space-x-2 text-xs">
-              {isRegionsLayerActive && (
-                <span className="whitespace-nowrap">Location selected:</span>
-              )}
-              {isRegionsLayerActive && !!nutsDataResponse?.NUTS_NAME && (
-                <div className="flex space-x-2.5 whitespace-nowrap rounded-full bg-white-950 px-2 py-0.5 text-left font-satoshi font-medium">
-                  {label}
-                </div>
-              )}
-            </div>
-            <div className="space-x-2 text-[22px]">
-              {typeof data.value === 'number' ? (
-                <span>{numberFormat(data.value)}</span>
-              ) : (
-                data.value
-              )}
-              {!!data.unit && <span>{data.unit}</span>}
-            </div>
-          </>
-        )}
-
-        {hasLayer && !hasValue && (
-          <span>No data is available at this specific location.</span>
-        )}
-
-        {hasLayer && hasValue && !isRegionsLayerActive && (
-          <Button variant="outline" onClick={handleClick}>
-            Show point histogram
-          </Button>
-        )}
-        {hasLayer && hasValue && isRegionsLayerActive && (
-          <Button variant="outline" onClick={handleHistogram}>
-            Show region histogram
-          </Button>
-        )}
+        <div
+          aria-hidden
+          className={`size-3.5 absolute left-1/2 -translate-x-1/2 rotate-45 bg-black-150 ${
+            tailOnTop ? '-top-1.5' : '-bottom-1.5'
+          }`}
+        />
       </div>
     </div>
   );

--- a/src/components/map/tooltip/index.tsx
+++ b/src/components/map/tooltip/index.tsx
@@ -12,6 +12,7 @@ import {
 } from 'react';
 
 import { useAtom, useSetAtom, useAtomValue } from 'jotai';
+import { toLonLat } from 'ol/proj';
 import { LuX } from 'react-icons/lu';
 
 import {
@@ -53,7 +54,12 @@ type MapTooltipProps = Omit<TooltipProps, 'leftData' | 'rightData'> & {
   data: TooltipProps['leftData'] | TooltipProps['rightData'];
 };
 
-const MapTooltip: FC<MapTooltipProps> = ({ position, onCloseTooltip = () => null, data }) => {
+const MapTooltip: FC<MapTooltipProps> = ({
+  position,
+  coordinate,
+  onCloseTooltip = () => null,
+  data,
+}) => {
   const isHistogramVisibility = useSetAtom(histogramVisibilityAtom);
   const nutsDataResponse = useAtomValue(nutsDataResponseAtom);
   const countryName = useCountryName(nutsDataResponse?.CNTR_CODE);
@@ -138,6 +144,17 @@ const MapTooltip: FC<MapTooltipProps> = ({ position, onCloseTooltip = () => null
   const hasValue = data?.value !== null && data?.value !== undefined && data?.value !== 0;
   const label = [countryName, nutsDataResponse?.NUTS_NAME].filter(Boolean).join(', ');
 
+  const lonLat: [number, number] | null = (() => {
+    if (!coordinate || coordinate.length < 2) return null;
+    const [lon, lat] = toLonLat([coordinate[0], coordinate[1]]);
+    if (!Number.isFinite(lon) || !Number.isFinite(lat)) return null;
+    return [lon, lat];
+  })();
+  const formatDeg = (n: number) => `${n.toFixed(4)}°`;
+  // Show a coordinate readout when there's no human-readable place name —
+  // i.e. point queries, and region queries that came back without a NUTS_NAME.
+  const showCoords = !!lonLat && hasLayer && (!isRegionsLayerActive || !nutsDataResponse?.NUTS_NAME);
+
   return (
     <div
       ref={ref}
@@ -182,6 +199,24 @@ const MapTooltip: FC<MapTooltipProps> = ({ position, onCloseTooltip = () => null
           {!hasLayer && (
             <p data-testid="map-tooltip-no-layer" className="text-xs">
               Activate at least one layer from the sidebar to see data for this location.
+            </p>
+          )}
+
+          {showCoords && lonLat && (
+            <p
+              data-testid="map-tooltip-coordinates"
+              className="flex items-center gap-3 text-xs"
+            >
+              <span className="whitespace-nowrap">Coordinates:</span>
+              <span className="whitespace-nowrap rounded-full bg-white-950 px-2 py-0.5 font-mono">
+                <span aria-label={`Latitude ${lonLat[1].toFixed(4)} degrees`}>
+                  {formatDeg(lonLat[1])}
+                </span>
+                <span aria-hidden="true">, </span>
+                <span aria-label={`Longitude ${lonLat[0].toFixed(4)} degrees`}>
+                  {formatDeg(lonLat[0])}
+                </span>
+              </span>
             </p>
           )}
 

--- a/src/components/map/tooltip/index.tsx
+++ b/src/components/map/tooltip/index.tsx
@@ -25,6 +25,7 @@ import { CATEGORIES_COLORS } from '@/constants/categories';
 
 import { useCountryName } from '@/hooks/countries';
 import { useLayer } from '@/hooks/layers';
+import { scrollToHistogram } from '@/lib/scroll-to-histogram';
 
 import type { MonitorTooltipInfo } from '@/components/map/types';
 import { Button } from '@/components/ui/button';
@@ -33,21 +34,6 @@ import { AnalysisSVG } from '@/SVGS/analysis';
 
 interface TooltipProps extends MonitorTooltipInfo {
   onCloseTooltip: () => void;
-}
-
-function scrollToHistogram(theId: string) {
-  const vp = document.getElementById('sidebar-scroll-viewport');
-  const el = document.getElementById(`histogram-anchor-${theId}`);
-
-  if (!vp || !el) return;
-  el.scrollIntoView({ behavior: 'smooth', block: 'start', inline: 'nearest' });
-
-  const sticky = vp.querySelector('.sticky') as HTMLElement | null;
-  const offset = (sticky?.offsetHeight ?? 0) + 8;
-
-  requestAnimationFrame(() => {
-    vp.scrollTo({ top: vp.scrollTop - offset, behavior: 'smooth' });
-  });
 }
 
 type MapTooltipProps = Omit<TooltipProps, 'leftData' | 'rightData'> & {
@@ -202,9 +188,14 @@ const MapTooltip: FC<MapTooltipProps> = ({
           data-testid="map-tooltip-close"
           onClick={onCloseTooltip}
           aria-label="Close tooltip"
-          className="size-[34px] absolute -right-2 -top-2 z-10 flex items-center justify-center rounded-full border border-white-800 bg-black-150 text-white-500 transition-colors hover:border-white-500 hover:text-white-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white-500 focus-visible:ring-offset-2 focus-visible:ring-offset-black-150"
+          className="absolute right-[-17px] top-5 z-10 flex h-[34px] w-[34px] items-center justify-center rounded-full border border-white-500/[0.08] bg-black-150 text-white-500 transition-colors hover:border-white-500 hover:text-white-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white-500 focus-visible:ring-offset-2 focus-visible:ring-offset-black-150"
         >
-          <LuX aria-hidden="true" focusable="false" className="size-4" />
+          <span
+            aria-hidden="true"
+            className="flex h-[18px] w-[18px] items-center justify-center rounded-full border border-white-500"
+          >
+            <LuX focusable="false" className="h-[9px] w-[9px]" strokeWidth={1.5} />
+          </span>
         </button>
 
         <div id={bodyId} className="flex flex-col gap-3">

--- a/src/components/map/tooltip/index.tsx
+++ b/src/components/map/tooltip/index.tsx
@@ -100,14 +100,16 @@ const MapTooltip: FC<MapTooltipProps> = ({ position, onCloseTooltip = () => null
     setCoords((prev) => (prev?.left === left && prev?.top === top ? prev : { left, top }));
   });
 
-  if (!position || (data?.value === undefined && data?.value !== 0)) return null;
+  if (!position) return null;
 
+  const hasLayer = !!data?.id;
+  const hasValue = data?.value !== null && data?.value !== undefined && data?.value !== 0;
   const label = [nutsDataResponse?.NUTS_NAME, countryName].filter(Boolean).join(', ');
 
   return (
     <div
       ref={ref}
-      className="absolute z-50 min-w-[250px] rounded-[20px] bg-black-150 p-5 font-satoshi font-medium text-white-500 shadow-md"
+      className="absolute z-50 min-w-[250px] max-w-[320px] rounded-[20px] bg-black-150 p-5 font-satoshi font-medium text-white-500 shadow-md"
       style={{
         left: `${coords?.left ?? position[0]}px`,
         top: `${coords?.top ?? position[1] - 10}px`,
@@ -118,14 +120,21 @@ const MapTooltip: FC<MapTooltipProps> = ({ position, onCloseTooltip = () => null
         <div className="flex w-full items-start justify-between space-x-2">
           <AnalysisSVG className="h-6 w-6 flex-shrink-0" />
           <h3 style={{ color }} className="break-word flex max-w-[300px] flex-wrap  text-left ">
-            {data.title}
+            {hasLayer ? data.title : 'No layer active'}
           </h3>
 
           <button type="button" onClick={onCloseTooltip}>
             <LuX className="h-6 w-6" />
           </button>
         </div>
-        {data.value !== 0 && (
+
+        {!hasLayer && (
+          <span>
+            Activate at least one layer from the sidebar to see data for this location.
+          </span>
+        )}
+
+        {hasLayer && hasValue && (
           <>
             <div className="flex items-center space-x-2 text-xs">
               {isRegionsLayerActive && (
@@ -143,17 +152,21 @@ const MapTooltip: FC<MapTooltipProps> = ({ position, onCloseTooltip = () => null
               ) : (
                 data.value
               )}
-              {!!data.unit && !!data.value && <span>{data.unit}</span>}
+              {!!data.unit && <span>{data.unit}</span>}
             </div>
           </>
         )}
-        {!data.value && <span>No data is available at this specific location.</span>}
-        {data?.value && !isRegionsLayerActive && (
-          <Button variant="outline" onClick={handleClick} disabled={!data.value}>
+
+        {hasLayer && !hasValue && (
+          <span>No data is available at this specific location.</span>
+        )}
+
+        {hasLayer && hasValue && !isRegionsLayerActive && (
+          <Button variant="outline" onClick={handleClick}>
             Show point histogram
           </Button>
         )}
-        {data?.value && isRegionsLayerActive && (
+        {hasLayer && hasValue && isRegionsLayerActive && (
           <Button variant="outline" onClick={handleHistogram}>
             Show region histogram
           </Button>

--- a/src/components/map/tooltip/index.tsx
+++ b/src/components/map/tooltip/index.tsx
@@ -60,7 +60,7 @@ const MapTooltip: FC<MapTooltipProps> = ({
   onCloseTooltip = () => null,
   data,
 }) => {
-  const isHistogramVisibility = useSetAtom(histogramVisibilityAtom);
+  const [isHistogramActive, setHistogramVisibility] = useAtom(histogramVisibilityAtom);
   const nutsDataResponse = useAtomValue(nutsDataResponseAtom);
   const countryName = useCountryName(nutsDataResponse?.CNTR_CODE);
 
@@ -68,18 +68,42 @@ const MapTooltip: FC<MapTooltipProps> = ({
     layer_id: data.id,
   });
 
+  const revealHistogram = useCallback(
+    (id?: string) => {
+      if (!id) return;
+      setHistogramVisibility(true);
+      // Defer until after the visibility state flips and the histogram is in
+      // the DOM, otherwise the anchor can't be found.
+      requestAnimationFrame(() => {
+        scrollToHistogram(id);
+      });
+    },
+    [setHistogramVisibility]
+  );
+
   const handleHistogram = useCallback(() => {
-    isHistogramVisibility(true);
-  }, [isHistogramVisibility]);
+    revealHistogram(data?.id);
+  }, [revealHistogram, data?.id]);
 
   const [isRegionsLayerActive] = useAtom(regionsLayerVisibilityAtom);
 
   const handleClick = useCallback(() => {
-    isHistogramVisibility(true);
+    revealHistogram(data?.id);
+  }, [revealHistogram, data?.id]);
+
+  // Clicking a new map location refreshes this tooltip with new coordinates.
+  // If the histogram panel is already visible the user expects it to follow
+  // the new selection, so scroll the sidebar to the corresponding anchor.
+  const lastScrolledKey = useRef<string | null>(null);
+  useEffect(() => {
+    if (!isHistogramActive || !data?.id || !position) return;
+    const key = `${data.id}:${position[0]}:${position[1]}`;
+    if (lastScrolledKey.current === key) return;
+    lastScrolledKey.current = key;
     requestAnimationFrame(() => {
-      scrollToHistogram(data?.id);
+      scrollToHistogram(data.id);
     });
-  }, [isHistogramVisibility, data?.id]);
+  }, [isHistogramActive, data?.id, position]);
 
   const color = useMemo(() => {
     return (

--- a/src/components/theme-filter/map-sidebar-item.tsx
+++ b/src/components/theme-filter/map-sidebar-item.tsx
@@ -27,11 +27,19 @@ const SidebarItem = ({ Icon, button: btn }: SidebarItemProps) => {
   const [categories, setCategory] = useSyncCategories();
   const [isHovered, setIsHovered] = useState(false);
 
-  const isActive = categories?.[0] === btn.id;
   const isAll = btn.id === ALL_CATEGORY.id;
+  const isActive = isAll
+    ? categories === 'All' || categories == null
+    : Array.isArray(categories) && categories[0] === btn.id;
   const categoryColor = CATEGORIES_COLORS[btn.id]?.base ?? CATEGORIES_COLORS['Unknown']?.base;
 
-  const handleClick = () => setCategory([btn.id] as CategoryId[] | 'All');
+  const handleClick = () => {
+    if (isAll) {
+      setCategory('All');
+      return;
+    }
+    setCategory([btn.id] as CategoryId[]);
+  };
 
   /**
    * Outer button style — border-2 + p-[2px] always present (constant size = 40px).
@@ -75,11 +83,15 @@ const SidebarItem = ({ Icon, button: btn }: SidebarItemProps) => {
     <Tooltip delayDuration={300}>
       <TooltipTrigger asChild>
         <button
+          type="button"
+          data-testid={`map-sidebar-category-${btn.id}`}
           aria-label={btn.label}
           aria-pressed={isActive}
-          className="rounded-full p-2 transition-all duration-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-green focus-visible:ring-offset-2 focus-visible:ring-offset-black-500"
+          className="relative rounded-full p-2 transition-all duration-300 before:absolute before:-inset-0.5 before:content-[''] focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-green focus-visible:ring-offset-2 focus-visible:ring-offset-black-500"
           style={outerStyle()}
           onClick={handleClick}
+          onFocus={() => setIsHovered(true)}
+          onBlur={() => setIsHovered(false)}
           onMouseEnter={() => setIsHovered(true)}
           onMouseLeave={() => setIsHovered(false)}
         >

--- a/src/components/theme-filter/map-sidebar.tsx
+++ b/src/components/theme-filter/map-sidebar.tsx
@@ -9,7 +9,8 @@ import SidebarItem from './map-sidebar-item';
 
 const SidebarThemeFilters = () => {
   const [categories] = useSyncCategories();
-  const selectedCategory = categories?.[0] ?? null;
+  const selectedCategory =
+    categories === 'All' || categories == null ? ALL_CATEGORY.id : categories[0] ?? null;
 
   return (
     <aside
@@ -17,11 +18,11 @@ const SidebarThemeFilters = () => {
       className="fixed bottom-0 left-0 top-0 z-10 flex w-full flex-col justify-start gap-y-3 bg-black-400 py-12 text-white-500"
       style={{ width: SIDEBAR_THEME_FILTERS }}
     >
-      <span className="mx-auto flex items-center text-center text-xs text-white-500/50">
+      <span id="theme-filter-heading" className="mx-auto flex items-center text-center text-xs text-white-500/50">
         Select a Category
       </span>
       <nav
-        aria-label="Theme categories"
+        aria-labelledby="theme-filter-heading"
         className="mx-auto flex h-full flex-col items-center justify-start space-y-2 p-2"
       >
         <ul role="list" className="flex w-full flex-col items-center space-y-3">

--- a/src/lib/scroll-to-histogram.ts
+++ b/src/lib/scroll-to-histogram.ts
@@ -1,0 +1,22 @@
+/**
+ * Scroll the sidebar viewport to the `histogram-anchor-${id}` card and
+ * compensate for the sticky header that sits at the top of the viewport,
+ * so the histogram lands fully visible — not hidden underneath it.
+ */
+export function scrollToHistogram(id: string) {
+  if (!id) return;
+  if (typeof document === 'undefined') return;
+
+  const vp = document.getElementById('sidebar-scroll-viewport');
+  const el = document.getElementById(`histogram-anchor-${id}`);
+  if (!vp || !el) return;
+
+  el.scrollIntoView({ behavior: 'smooth', block: 'start', inline: 'nearest' });
+
+  const sticky = vp.querySelector('.sticky') as HTMLElement | null;
+  const offset = (sticky?.offsetHeight ?? 0) + 8;
+
+  requestAnimationFrame(() => {
+    vp.scrollTo({ top: vp.scrollTop - offset, behavior: 'smooth' });
+  });
+}

--- a/src/lib/scroll-to-histogram.ts
+++ b/src/lib/scroll-to-histogram.ts
@@ -1,7 +1,8 @@
 /**
- * Scroll the sidebar viewport to the `histogram-anchor-${id}` card and
- * compensate for the sticky header that sits at the top of the viewport,
- * so the histogram lands fully visible — not hidden underneath it.
+ * Scroll the sidebar viewport so the dataset card for `id` lands
+ * directly under the sticky header. Computes the target offset
+ * in a single `scrollTo` call to avoid racing with the smooth
+ * animation of `scrollIntoView` + a post-scroll adjustment.
  */
 export function scrollToHistogram(id: string) {
   if (!id) return;
@@ -11,12 +12,12 @@ export function scrollToHistogram(id: string) {
   const el = document.getElementById(`histogram-anchor-${id}`);
   if (!vp || !el) return;
 
-  el.scrollIntoView({ behavior: 'smooth', block: 'start', inline: 'nearest' });
-
   const sticky = vp.querySelector('.sticky') as HTMLElement | null;
   const offset = (sticky?.offsetHeight ?? 0) + 8;
 
-  requestAnimationFrame(() => {
-    vp.scrollTo({ top: vp.scrollTop - offset, behavior: 'smooth' });
-  });
+  const vpRect = vp.getBoundingClientRect();
+  const elRect = el.getBoundingClientRect();
+  const target = vp.scrollTop + (elRect.top - vpRect.top) - offset;
+
+  vp.scrollTo({ top: Math.max(target, 0), behavior: 'smooth' });
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -264,12 +264,6 @@
   left: 2px !important;
 }
 
-.cesium-credit-wrapper {
-  position: fixed !important;
-  bottom: 0px !important;
-  right: 40px !important;
-}
-
 .arrow {
   height: 15px;
   width: 15px;


### PR DESCRIPTION
- Render tooltip on every map click, including when no layer is active (shows explanatory message)
- Keep tooltip open on layer/compare-layer change so GFI refetches in place
- Sync nutsDataParams.LAYER_ID with the active layer so the region histogram retargets when layers swap
- Populate nutsDataParams when the regions layer is activated after a click
- Reset histogram visibility and NUTS params when no layer is active