### PR TITLE
feat: move Cesium attribution to bottom-right with platform tooltip

### DIFF
--- a/src/components/globe/cesium-attribution.tsx
+++ b/src/components/globe/cesium-attribution.tsx
@@ -128,7 +128,7 @@ export default function CesiumAttribution() {
   return (
     <div
       data-testid="cesium-attribution"
-      className="pointer-events-auto absolute bottom-5 right-5 z-10 flex items-center gap-3 md:bottom-[72px] xl:bottom-5"
+      className="pointer-events-auto absolute bottom-2 right-5 z-10 flex items-center gap-3 md:bottom-[60px] xl:bottom-2"
     >
       <a
         href="https://cesium.com/"
@@ -140,14 +140,14 @@ export default function CesiumAttribution() {
         <Image
           src="/cesium/Assets/Images/cesium_credit.png"
           alt="Cesium"
-          width={59}
-          height={15}
+          width={88}
+          height={22}
           priority
           unoptimized
         />
       </a>
       {credits.length > 0 && (
-        <Tooltip>
+        <Tooltip delayDuration={0}>
           <TooltipTrigger asChild>
             <button
               type="button"

--- a/src/components/globe/cesium-attribution.tsx
+++ b/src/components/globe/cesium-attribution.tsx
@@ -1,0 +1,176 @@
+'use client';
+
+import { createElement, Fragment, ReactNode, useEffect, useMemo, useState } from 'react';
+
+import Image from 'next/image';
+
+import { useCesium } from 'resium';
+
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+
+const POLL_MS = 500;
+
+const ALLOWED_TAGS = new Set(['A', 'SPAN', 'B', 'I', 'EM', 'STRONG', 'BR', 'SUP', 'SUB']);
+const ALLOWED_ATTRS: Record<string, Set<string>> = {
+  A: new Set(['href', 'target', 'rel', 'title']),
+};
+const SAFE_URL = /^(https?:|mailto:)/i;
+
+function renderSafeNode(node: ChildNode, key: number): ReactNode {
+  if (node.nodeType === Node.TEXT_NODE) return node.textContent ?? '';
+  if (node.nodeType !== Node.ELEMENT_NODE) return null;
+
+  const el = node as Element;
+  const tag = el.tagName;
+  const children = Array.from(el.childNodes).map((child, i) => renderSafeNode(child, i));
+
+  if (!ALLOWED_TAGS.has(tag)) {
+    return createElement(Fragment, { key }, ...children);
+  }
+
+  const props: Record<string, string> = { key: String(key) };
+  const allowed = ALLOWED_ATTRS[tag];
+  if (allowed) {
+    for (const attr of Array.from(el.attributes)) {
+      if (!allowed.has(attr.name)) continue;
+      if (attr.name === 'href' && !SAFE_URL.test(attr.value)) continue;
+      props[attr.name] = attr.value;
+    }
+  }
+  if (tag === 'A') {
+    props.target = props.target || '_blank';
+    props.rel = 'noopener noreferrer';
+  }
+
+  return createElement(tag.toLowerCase(), props, ...children);
+}
+
+function renderSafeHtml(html: string): ReactNode {
+  if (typeof window === 'undefined') return null;
+  const doc = new DOMParser().parseFromString(`<div>${html}</div>`, 'text/html');
+  const root = doc.body.firstChild;
+  if (!root) return null;
+  return Array.from(root.childNodes).map((child, i) => renderSafeNode(child, i));
+}
+
+function toArray(maybeArray: unknown): unknown[] {
+  if (!maybeArray) return [];
+  if (Array.isArray(maybeArray)) return maybeArray;
+  const candidate = (maybeArray as { values?: unknown }).values;
+  if (Array.isArray(candidate)) return candidate;
+  if (typeof candidate === 'function') {
+    try {
+      return Array.from((candidate as () => Iterable<unknown>).call(maybeArray));
+    } catch {
+      return [];
+    }
+  }
+  return [];
+}
+
+function collectCreditHtml(creditDisplay: unknown): string[] {
+  if (!creditDisplay) return [];
+  const cd = creditDisplay as Record<string, unknown>;
+  const frame = cd._currentFrameCredits as Record<string, unknown> | undefined;
+  const sources = [
+    frame?.lightboxCredits,
+    frame?.screenCredits,
+    cd._defaultCredits,
+    cd._defaultCredit ? [cd._defaultCredit] : undefined,
+  ];
+
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const source of sources) {
+    for (const entry of toArray(source)) {
+      const credit = (entry as { credit?: { html?: string }; html?: string })?.credit ?? entry;
+      const html = (credit as { html?: string })?.html?.trim();
+      if (html && !seen.has(html)) {
+        seen.add(html);
+        out.push(html);
+      }
+    }
+  }
+  return out;
+}
+
+export default function CesiumAttribution() {
+  const { viewer } = useCesium();
+  const [credits, setCredits] = useState<string[]>([]);
+  const rendered = useMemo(
+    () => credits.map((html) => ({ html, node: renderSafeHtml(html) })),
+    [credits]
+  );
+
+  useEffect(() => {
+    if (!viewer) return;
+    let cancelled = false;
+    let lastSignature = '';
+
+    const tick = () => {
+      if (cancelled) return;
+      const next = collectCreditHtml(viewer.creditDisplay);
+      const sig = next.join('||');
+      if (sig !== lastSignature) {
+        lastSignature = sig;
+        setCredits(next);
+      }
+    };
+
+    tick();
+    const id = window.setInterval(tick, POLL_MS);
+    return () => {
+      cancelled = true;
+      window.clearInterval(id);
+    };
+  }, [viewer]);
+
+  return (
+    <div
+      data-testid="cesium-attribution"
+      className="pointer-events-auto absolute bottom-5 right-5 z-10 flex items-center gap-3 md:bottom-[72px] xl:bottom-5"
+    >
+      <a
+        href="https://cesium.com/"
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label="Cesium"
+        className="rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-green"
+      >
+        <Image
+          src="/cesium/Assets/Images/cesium_credit.png"
+          alt="Cesium"
+          width={59}
+          height={15}
+          priority
+          unoptimized
+        />
+      </a>
+      {credits.length > 0 && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              data-testid="cesium-data-attribution"
+              className="rounded text-[10px] text-white-50 underline shadow-brand-500 drop-shadow-[2px_2px_2px_var(--tw-shadow-color)] focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-green"
+            >
+              Data attribution
+            </button>
+          </TooltipTrigger>
+          <TooltipContent
+            side="top"
+            align="end"
+            sideOffset={8}
+            className="max-w-xs border border-secondary-500 bg-secondary-500 text-[11px] leading-snug text-brand-500 [&_a]:rounded [&_a]:underline [&_a]:focus:outline-none [&_a]:focus-visible:ring-2 [&_a]:focus-visible:ring-accent-green"
+          >
+            <ul className="space-y-1">
+              {rendered.map(({ html, node }) => (
+                <li key={html}>{node}</li>
+              ))}
+            </ul>
+          </TooltipContent>
+        </Tooltip>
+      )}
+    </div>
+  );
+}

--- a/src/components/globe/index.tsx
+++ b/src/components/globe/index.tsx
@@ -23,6 +23,7 @@ import cn from '@/lib/classnames';
 import type { GeostoryPin } from '@/app/(landing)/geostory-pins';
 
 import CameraConstraints from './camera-constraints';
+import CesiumAttribution from './cesium-attribution';
 import { colorForCategory, createDiamondDataUrl } from './diamond-pin';
 import DynamicLighting from './dynamic-lighting';
 import FlyToCenter from './fly-to-center';
@@ -194,6 +195,8 @@ export default function Map3D({
             </Entity>
           );
         })}
+
+        <CesiumAttribution />
       </Viewer>
     </div>
   );

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -302,86 +302,11 @@
 }
 
 .cesium-viewer-bottom,
-.cesium-credit-wrapper {
-  bottom: 72px !important;
-}
-
-@media (max-width: 450px) {
-  .cesium-viewer-bottom,
-  .cesium-credit-wrapper {
-    bottom: 72px !important;
-  }
+.cesium-credit-lightbox-overlay {
+  display: none !important;
 }
 
 .cesium-widget,
 .cesium-widget canvas {
   background: transparent !important;
-}
-
-@media (max-width: 450px) {
-  .cesium-credit-lightbox-overlay {
-    z-index: 100000000;
-    position: fixed !important;
-    inset: 0 !important;
-    top: 50% !important;
-    left: 50% !important;
-    transform: translate(-50%, -50%) !important;
-    max-height: 100px !important;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-
-    background-image: url('/images/landing/bg.png') !important;
-    background-size: cover !important;
-    background-position: center !important;
-    background-repeat: no-repeat !important;
-  }
-
-  .cesium-credit-lightbox-overlay .cesium-credit-wrapper {
-    background-image: url('/images/landing/bg.png') !important;
-
-    background-size: cover !important;
-    background-size: cover !important;
-    background-position: center !important;
-    background-repeat: no-repeat !important;
-
-    border: none !important;
-    bottom: 10px !important;
-    left: 20px !important;
-  }
-}
-
-@media (min-width: 451px) {
-  .cesium-credit-lightbox-overlay {
-    z-index: 100000000;
-    position: fixed !important;
-
-    left: 50% !important;
-    bottom: 50% !important;
-    transform: translate(-50%, -50%) !important;
-    max-width: 200px;
-    max-height: 100px !important;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    background-image: url('/images/landing/bg.png') !important;
-    background-position: center !important;
-    background-size: cover !important;
-    background-position: center !important;
-    background-repeat: no-repeat !important;
-  }
-
-  .cesium-credit-lightbox-overlay .cesium-credit-wrapper {
-    background-image: url('/images/landing/bg.png') !important;
-
-    background-repeat: no-repeat !important;
-    background-size: cover !important;
-    background-position: center !important;
-    background-repeat: no-repeat !important;
-
-    border: none !important;
-    bottom: 10px !important;
-    left: 20px !important;
-    position: absolute !important;
-  }
 }


### PR DESCRIPTION
## Summary
- Replace native Cesium credit display and lightbox modal with a custom React component anchored to the bottom-right of the globe, 20px above the footer on both mobile and desktop.
- Click on **Data attribution** now opens a Radix tooltip styled to match the platform (secondary/brand palette) instead of a centered modal.
- Credits are read dynamically from `viewer.creditDisplay` (lightbox + screen + defaults) and rendered through an allowlist DOM sanitizer (no `dangerouslySetInnerHTML`).

## Implementation notes
- `src/components/globe/cesium-attribution.tsx` (new):
  - Mounted inside the Resium `<Viewer>` tree, uses `useCesium()` to access the viewer.
  - Polls credit display every 500 ms, dedupes by HTML signature.
  - Sanitizes credit HTML via DOMParser: allows only `a, span, b, i, em, strong, br, sup, sub`; `<a>` keeps `href, target, rel, title`, restricts `href` to `https?|mailto`, forces `rel=\"noopener noreferrer\" target=\"_blank\"`. Disallowed tags fall through to their text children. Blocks `<script>`, event handlers, `javascript:` URLs.
- Responsive bottom offset to honour the 20 px gap above the footer (footer behaviour differs across breakpoints):
  - `<768` (FooterDesktop, in flow): `bottom-5`
  - `768–1279` (FooterMobile, fixed ~52 px): `bottom-[72px]`
  - `>=1280` (FooterDesktop, in flow): `bottom-5`
- `src/components/globe/index.tsx`: render `<CesiumAttribution />` inside `<Viewer>`.
- `src/styles/globals.css`: hide native `.cesium-viewer-bottom` and `.cesium-credit-lightbox-overlay`; drop obsolete lightbox styling.

## Test plan
- [ ] Landing page on mobile (<768): logo + \"Data attribution\" sit at bottom-right, 20 px above the (non-fixed) FooterDesktop.
- [ ] Landing page on tablet (768–1279): logo + \"Data attribution\" sit 20 px above the fixed FooterMobile.
- [ ] Landing page on desktop (>=1280): logo + \"Data attribution\" sit 20 px above FooterDesktop, not clipped.
- [ ] Clicking the Cesium logo opens https://cesium.com in a new tab.
- [ ] Clicking/hovering \"Data attribution\" opens the platform-styled tooltip containing the Esri credit; link in tooltip is clickable and opens in a new tab.
- [ ] Native Cesium modal (lightbox overlay) no longer appears.
- [ ] No regressions on `/explore` (OpenLayers map / `Attributions` component unaffected).
- [ ] `yarn check-types` passes.