### PR TITLE
fix: legend unit, sidebar scroll, More info icon, Expand/Collapse buttons

### DIFF
--- a/src/components/geostories/dialog/index.tsx
+++ b/src/components/geostories/dialog/index.tsx
@@ -3,12 +3,9 @@ import { useMemo } from 'react';
 import { compact } from 'lodash-es';
 import { LuInfo } from 'react-icons/lu';
 
-import cn from '@/lib/classnames';
-
 import type { Geostory } from '@/types/geostories';
 
 import UseCases from '@/components/monitors/dialog/knowledge-package';
-import { buttonVariants } from '@/components/ui/button';
 import {
   Dialog,
   DialogContent,
@@ -47,10 +44,10 @@ const GeostoryDialog: React.FC<GeostoryDialogProps> = ({
       <DialogTrigger
         title="More info"
         data-testid={`card-button-${id}`}
-        className="flex items-center space-x-3 rounded text-xs font-bold focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-green"
+        className="group flex items-center space-x-3 rounded text-xs font-bold focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-green"
       >
         <LuInfo
-          className={cn(buttonVariants({ variant: 'outline', size: 'icon' }), 'h-9 w-9 p-2')}
+          className="h-6 w-6 transition-colors group-hover:text-accent-green"
           aria-hidden="true"
         />
         <span>More info</span>

--- a/src/components/geostories/dialog/index.tsx
+++ b/src/components/geostories/dialog/index.tsx
@@ -3,9 +3,12 @@ import { useMemo } from 'react';
 import { compact } from 'lodash-es';
 import { LuInfo } from 'react-icons/lu';
 
+import cn from '@/lib/classnames';
+
 import type { Geostory } from '@/types/geostories';
 
 import UseCases from '@/components/monitors/dialog/knowledge-package';
+import { buttonVariants } from '@/components/ui/button';
 import {
   Dialog,
   DialogContent,
@@ -15,7 +18,6 @@ import {
   DialogTrigger,
   DialogClose,
 } from '@/components/ui/dialog';
-import { IconTooltip } from '@/components/ui/tooltip';
 
 type GeostoryDialogProps = Partial<Geostory>;
 
@@ -42,15 +44,17 @@ const GeostoryDialog: React.FC<GeostoryDialogProps> = ({
 
   return (
     <Dialog>
-      <IconTooltip label="More info">
-        <DialogTrigger
-          data-testid={`card-button-${id}`}
-          className="flex items-center space-x-3 rounded text-xs font-bold focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-green"
-        >
-          <LuInfo className="h-6 w-6" aria-hidden="true" />
-          <span>More info</span>
-        </DialogTrigger>
-      </IconTooltip>
+      <DialogTrigger
+        title="More info"
+        data-testid={`card-button-${id}`}
+        className="flex items-center space-x-3 rounded text-xs font-bold focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-green"
+      >
+        <LuInfo
+          className={cn(buttonVariants({ variant: 'outline', size: 'icon' }), 'h-9 w-9 p-2')}
+          aria-hidden="true"
+        />
+        <span>More info</span>
+      </DialogTrigger>
       <DialogContent
         data-testid={`geostory-card-${id}`}
         className="w-full bg-secondary-500 text-brand-500 sm:w-[665px]"

--- a/src/components/geostories/dialog/index.tsx
+++ b/src/components/geostories/dialog/index.tsx
@@ -47,7 +47,7 @@ const GeostoryDialog: React.FC<GeostoryDialogProps> = ({
         className="group flex items-center space-x-3 rounded text-xs font-bold focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-green"
       >
         <LuInfo
-          className="h-6 w-6 transition-colors group-hover:text-accent-green"
+          className="h-6 w-6 text-white-800 transition-colors group-hover:text-white-500"
           aria-hidden="true"
         />
         <span>More info</span>

--- a/src/components/geostories/view/index.tsx
+++ b/src/components/geostories/view/index.tsx
@@ -52,7 +52,7 @@ const GeostoriesView: FC<GeostoriesViewProps> = ({ data, geostoryLayers, compari
               <Button
                 variant={datasetStatus === 'open' ? 'outline' : 'default'}
                 size="sm"
-                className="flex w-fit items-center gap-1 p-0 data-[state=open]:bg-transparent"
+                className="flex w-fit items-center gap-1"
               >
                 {datasetStatus === 'open' ? 'Collapse' : 'Expand'}
                 <ChevronDown
@@ -97,7 +97,7 @@ const GeostoriesView: FC<GeostoriesViewProps> = ({ data, geostoryLayers, compari
               <Button
                 variant={monitorStatus === 'open' ? 'outline' : 'default'}
                 size="sm"
-                className="flex w-fit items-center gap-1 p-0 data-[state=open]:bg-transparent"
+                className="flex w-fit items-center gap-1"
               >
                 {monitorStatus === 'open' ? 'Collapse' : 'Expand'}
                 <ChevronDown

--- a/src/components/geostories/view/index.tsx
+++ b/src/components/geostories/view/index.tsx
@@ -52,7 +52,7 @@ const GeostoriesView: FC<GeostoriesViewProps> = ({ data, geostoryLayers, compari
               <Button
                 variant={datasetStatus === 'open' ? 'outline' : 'default'}
                 size="sm"
-                className="flex w-fit items-center gap-1"
+                className="flex w-fit items-center gap-1 rounded-full"
               >
                 {datasetStatus === 'open' ? 'Collapse' : 'Expand'}
                 <ChevronDown
@@ -97,7 +97,7 @@ const GeostoriesView: FC<GeostoriesViewProps> = ({ data, geostoryLayers, compari
               <Button
                 variant={monitorStatus === 'open' ? 'outline' : 'default'}
                 size="sm"
-                className="flex w-fit items-center gap-1"
+                className="flex w-fit items-center gap-1 rounded-full"
               >
                 {monitorStatus === 'open' ? 'Collapse' : 'Expand'}
                 <ChevronDown

--- a/src/components/map/legend/graphic.tsx
+++ b/src/components/map/legend/graphic.tsx
@@ -53,7 +53,7 @@ export const LegendGraphic: React.FC<{
           ))}
         </div>
       )}
-      {(unit || unit !== 'no unit') && (
+      {unit && unit.trim().toLowerCase() !== 'no unit' && (
         <div title={unit} className="w-full text-right text-xs text-gray-600">
           {unit}
         </div>

--- a/src/components/monitors/dialog/index.tsx
+++ b/src/components/monitors/dialog/index.tsx
@@ -35,7 +35,7 @@ const MonitorDialog: React.FC<MonitorDialogProps> = ({
         className="group flex items-center space-x-3 rounded text-xs font-bold focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-green"
       >
         <LuInfo
-          className="h-6 w-6 transition-colors group-hover:text-accent-green"
+          className="h-6 w-6 text-white-800 transition-colors group-hover:text-white-500"
           aria-hidden="true"
         />
         <span>More info</span>

--- a/src/components/monitors/dialog/index.tsx
+++ b/src/components/monitors/dialog/index.tsx
@@ -1,10 +1,7 @@
 import { LuInfo } from 'react-icons/lu';
 
-import cn from '@/lib/classnames';
-
 import type { Monitor } from '@/types/monitors';
 
-import { buttonVariants } from '@/components/ui/button';
 import {
   Dialog,
   DialogContent,
@@ -35,10 +32,10 @@ const MonitorDialog: React.FC<MonitorDialogProps> = ({
       <DialogTrigger
         title="More info"
         data-testid={`card-button-${id}`}
-        className="flex items-center space-x-3 rounded text-xs font-bold focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-green"
+        className="group flex items-center space-x-3 rounded text-xs font-bold focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-green"
       >
         <LuInfo
-          className={cn(buttonVariants({ variant: 'outline', size: 'icon' }), 'h-9 w-9 p-2')}
+          className="h-6 w-6 transition-colors group-hover:text-accent-green"
           aria-hidden="true"
         />
         <span>More info</span>

--- a/src/components/monitors/dialog/index.tsx
+++ b/src/components/monitors/dialog/index.tsx
@@ -1,7 +1,10 @@
 import { LuInfo } from 'react-icons/lu';
 
+import cn from '@/lib/classnames';
+
 import type { Monitor } from '@/types/monitors';
 
+import { buttonVariants } from '@/components/ui/button';
 import {
   Dialog,
   DialogContent,
@@ -11,7 +14,6 @@ import {
   DialogTrigger,
   DialogClose,
 } from '@/components/ui/dialog';
-import { IconTooltip } from '@/components/ui/tooltip';
 
 import UseCases from './knowledge-package';
 
@@ -30,15 +32,17 @@ const MonitorDialog: React.FC<MonitorDialogProps> = ({
 
   return (
     <Dialog>
-      <IconTooltip label="More info">
-        <DialogTrigger
-          data-testid={`card-button-${id}`}
-          className="flex items-center space-x-3 rounded text-xs font-bold focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-green"
-        >
-          <LuInfo className="h-6 w-6" aria-hidden="true" />
-          <span>More info</span>
-        </DialogTrigger>
-      </IconTooltip>
+      <DialogTrigger
+        title="More info"
+        data-testid={`card-button-${id}`}
+        className="flex items-center space-x-3 rounded text-xs font-bold focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-green"
+      >
+        <LuInfo
+          className={cn(buttonVariants({ variant: 'outline', size: 'icon' }), 'h-9 w-9 p-2')}
+          aria-hidden="true"
+        />
+        <span>More info</span>
+      </DialogTrigger>
       <DialogContent
         data-testid={`monitor-card-${id}`}
         className="w-full bg-secondary-500 text-brand-500 sm:w-[665px]"

--- a/src/components/monitors/view/index.tsx
+++ b/src/components/monitors/view/index.tsx
@@ -46,7 +46,7 @@ const MonitorView: FC<MonitorViewProps> = ({ data, geostoryLayers }) => {
               <Button
                 variant={datasetStatus === 'open' ? 'outline' : 'default'}
                 size="sm"
-                className="flex w-fit items-center gap-1 p-0 data-[state=open]:bg-transparent"
+                className="flex w-fit items-center gap-1"
               >
                 {datasetStatus === 'open' ? 'Collapse' : 'Expand'}
                 <ChevronDown
@@ -90,7 +90,7 @@ const MonitorView: FC<MonitorViewProps> = ({ data, geostoryLayers }) => {
               <Button
                 variant={geostoryStatus === 'open' ? 'outline' : 'default'}
                 size="sm"
-                className="flex w-fit items-center gap-1 p-0 data-[state=open]:bg-transparent"
+                className="flex w-fit items-center gap-1"
               >
                 {geostoryStatus === 'open' ? 'Collapse' : 'Expand'}
                 <ChevronDown

--- a/src/components/monitors/view/index.tsx
+++ b/src/components/monitors/view/index.tsx
@@ -46,7 +46,7 @@ const MonitorView: FC<MonitorViewProps> = ({ data, geostoryLayers }) => {
               <Button
                 variant={datasetStatus === 'open' ? 'outline' : 'default'}
                 size="sm"
-                className="flex w-fit items-center gap-1"
+                className="flex w-fit items-center gap-1 rounded-full"
               >
                 {datasetStatus === 'open' ? 'Collapse' : 'Expand'}
                 <ChevronDown
@@ -90,7 +90,7 @@ const MonitorView: FC<MonitorViewProps> = ({ data, geostoryLayers }) => {
               <Button
                 variant={geostoryStatus === 'open' ? 'outline' : 'default'}
                 size="sm"
-                className="flex w-fit items-center gap-1"
+                className="flex w-fit items-center gap-1 rounded-full"
               >
                 {geostoryStatus === 'open' ? 'Collapse' : 'Expand'}
                 <ChevronDown

--- a/src/components/sidebar-wrapper/index.tsx
+++ b/src/components/sidebar-wrapper/index.tsx
@@ -15,7 +15,9 @@ export default function SidebarWrapper({ children }: { children: React.ReactNode
       {isMobile && children}
       {!isMobile && (
         <>
-          <Sidebar className="w-[448px] bg-black-400 px-8 py-12">{children}</Sidebar>
+          <Sidebar className="w-[448px] overflow-x-hidden bg-black-400 px-8 py-12">
+            {children}
+          </Sidebar>
           <SidebarAnchorElements />
         </>
       )}


### PR DESCRIPTION
## Summary

Map sidebar / legend / dialog UI fixes.

### 1. Hide legend unit when empty or "no unit"
`(unit || unit !== 'no unit')` was always truthy — empty `unit` rendered an empty right-aligned div. Now hides the unit row when `unit` is falsy or equals `"no unit"` (case- and whitespace-tolerant).
- `src/components/map/legend/graphic.tsx`

### 2. Prevent horizontal scroll in sidebar
`regions-banner.tsx` (`-mx-6 max-w-[420px]`) is wider than the sidebar content box (448px − `px-8` = 384px), producing a horizontal scrollbar. Added `overflow-x-hidden` to the sidebar scroll container.
- `src/components/sidebar-wrapper/index.tsx`

### 3. "More info" — drop tooltip, native title, icon hover
Removed the `IconTooltip` wrapper and added a native `title="More info"`. Icon rests at `text-white-800` and brightens to `text-white-500` on hover (no border, no green). Trigger is a `group` so the icon reacts to hover; label text is unchanged.
- `src/components/monitors/dialog/index.tsx`
- `src/components/geostories/dialog/index.tsx`

### 4. Dataset Expand/Collapse buttons
Removed `p-0 data-[state=open]:bg-transparent` and made them explicitly `rounded-full`, restoring the pill styling (green default "Expand" / outline "Collapse") with the chevron icon.
- `src/components/monitors/view/index.tsx`
- `src/components/geostories/view/index.tsx`

## Test plan

- [ ] Layer with a real unit → unit shown; empty / `"no unit"` → no unit row
- [ ] Explore sidebar → no horizontal scrollbar, content not clipped
- [ ] Monitor & geostory cards → "More info" shows native title on hover, icon brightens, opens dialog
- [ ] Datasets/Geostories/Monitors sections → Expand/Collapse render as rounded pills, toggle content