### PR TITLE
fix: explore UI refinements + bbox fly-to on entry

### DIFF
--- a/src/components/map/controls/bookmark/index.tsx
+++ b/src/components/map/controls/bookmark/index.tsx
@@ -102,15 +102,16 @@ export const BookmarkControl: FC<{ isMobile?: boolean }> = ({
                   <Button
                     type="submit"
                     onClick={handleSaveBookmark}
-                    className="flex w-full items-center"
+                    className="flex w-full items-center justify-center"
                     disabled={!bookmarkName}
                   >
                     Save
                   </Button>
                   <Button
                     type="button"
+                    variant="outline"
                     onClick={() => setInputVisibility(false)}
-                    className="flex w-full items-center"
+                    className="flex w-full items-center justify-center"
                   >
                     Cancel
                   </Button>
@@ -132,12 +133,10 @@ export const BookmarkControl: FC<{ isMobile?: boolean }> = ({
                   key={name}
                   className="border-t-0.5 flex items-center justify-between border-b border-t-[0.5px] border-dashed border-brand-50 py-2.5"
                 >
-                  <div className="flex items-center space-x-2">
-                    <AiFillStar className="h-5 w-5" />
-                    <a data-value={value} href={value}>
-                      {name}
-                    </a>
-                  </div>
+                  <a data-value={value} href={value} className="flex items-center space-x-2">
+                    <AiFillStar className="h-5 w-5" aria-hidden="true" />
+                    <span>{name}</span>
+                  </a>
                   <IconTooltip label="Remove bookmark" side="left">
                     <button
                       type="button"

--- a/src/components/map/index.tsx
+++ b/src/components/map/index.tsx
@@ -198,7 +198,7 @@ const Map: FC<CustomMapProps> = ({ initialViewState = DEFAULT_VIEWPORT }) => {
 
   // initial viewport
   const dataBbox = useMemo(
-    () => predefinedBbox || bbox || initialViewState.bbox,
+    () => bbox || predefinedBbox || initialViewState.bbox,
     [bbox, predefinedBbox, initialViewState.bbox]
   );
   const initialViewport = {
@@ -347,11 +347,23 @@ const Map: FC<CustomMapProps> = ({ initialViewState = DEFAULT_VIEWPORT }) => {
     setNutsDataParamsCompare({ NUTS_ID: '', LAYER_ID: '' });
   }, [setNutsDataParamsCompare]);
 
+  // Fit once per "entry" (mount / route change). The bbox URL param doubles as the
+  // live viewport (handleMapMove writes calculateExtent on every moveend), so reacting
+  // to it here would feed back into fit() and progressively zoom out. Guarding by entry
+  // key flies to the target on entry and ignores subsequent map-driven bbox updates.
+  const entryKey = `${type ?? ''}:${monitorId || (params.geostory_id as string) || ''}`;
+  const fittedEntryRef = useRef<string | null>(null);
+
   useEffect(() => {
-    if (!dataBbox || !mapRef?.current) return;
-    setBbox(dataBbox);
-    mapRef.current.ol.getView()?.fit(dataBbox);
-  }, [dataBbox, setBbox]);
+    if (!mapRef?.current) return;
+    if (fittedEntryRef.current === entryKey) return;
+    // URL bbox wins; otherwise wait for the API-provided predefinedBbox to load.
+    const target = bbox || predefinedBbox;
+    if (!target) return;
+    fittedEntryRef.current = entryKey;
+    setBbox(target);
+    mapRef.current.ol.getView()?.fit(target);
+  }, [entryKey, bbox, predefinedBbox, setBbox]);
 
   useEffect(() => {
     if (!isLayerActive) {

--- a/src/components/map/index.tsx
+++ b/src/components/map/index.tsx
@@ -198,7 +198,7 @@ const Map: FC<CustomMapProps> = ({ initialViewState = DEFAULT_VIEWPORT }) => {
 
   // initial viewport
   const dataBbox = useMemo(
-    () => bbox || predefinedBbox || initialViewState.bbox,
+    () => predefinedBbox || bbox || initialViewState.bbox,
     [bbox, predefinedBbox, initialViewState.bbox]
   );
   const initialViewport = {
@@ -357,8 +357,8 @@ const Map: FC<CustomMapProps> = ({ initialViewState = DEFAULT_VIEWPORT }) => {
   useEffect(() => {
     if (!mapRef?.current) return;
     if (fittedEntryRef.current === entryKey) return;
-    // URL bbox wins; otherwise wait for the API-provided predefinedBbox to load.
-    const target = bbox || predefinedBbox;
+    // API-provided predefinedBbox wins; otherwise fall back to the URL bbox.
+    const target = predefinedBbox || bbox;
     if (!target) return;
     fittedEntryRef.current = entryKey;
     setBbox(target);

--- a/src/components/monitors/dialog/index.tsx
+++ b/src/components/monitors/dialog/index.tsx
@@ -1,10 +1,7 @@
 import { LuInfo } from 'react-icons/lu';
 
-import cn from '@/lib/classnames';
-
 import type { Monitor } from '@/types/monitors';
 
-import { buttonVariants } from '@/components/ui/button';
 import {
   Dialog,
   DialogContent,

--- a/src/components/monitors/dialog/index.tsx
+++ b/src/components/monitors/dialog/index.tsx
@@ -1,7 +1,10 @@
 import { LuInfo } from 'react-icons/lu';
 
+import cn from '@/lib/classnames';
+
 import type { Monitor } from '@/types/monitors';
 
+import { buttonVariants } from '@/components/ui/button';
 import {
   Dialog,
   DialogContent,


### PR DESCRIPTION
## Summary

UI fixes and refinements across the explore map and sidebar, plus a bbox navigation fix.

### Legend & sidebar
- Hide legend unit when empty or `'no unit'`
- Prevent horizontal scroll in sidebar

### Monitor / Geostory dialogs
- "More info" icon: outline `buttonVariants` hover, native `title` over tooltip; brightens to `white-500` on hover
- Expand/Collapse buttons: restore pill styling, ensure fully rounded

### Bookmarks
- Cancel uses `outline` variant to differentiate from primary Save
- Center button text (`justify-center`)
- Saved-bookmark star icon wrapped inside the anchor, so clicking it navigates to the saved place

### Bbox fly-to
- Fit once per entry (mount/route change) via guard ref. The `bbox` param doubles as the live viewport (`handleMapMove` writes `calculateExtent` on every `moveEnd`), so reacting to it fed `fit()` back into itself and progressively zoomed out ("snap-back")
- `predefinedBbox` (API) is prioritized over the URL bbox for framing

## Test plan
- [ ] Legend hides unit when unit is empty / `'no unit'`
- [ ] Sidebar has no horizontal scroll
- [ ] "More info" icon brightens to `white-500` on hover in monitor & geostory dialogs
- [ ] Expand/Collapse buttons render as fully-rounded pills
- [ ] Bookmark Save (primary) and Cancel (outline) visually distinct, text centered
- [ ] Clicking the star on a saved bookmark navigates to it
- [ ] Opening a monitor/geostory flies to its bbox and stays (no snap-back)
- [ ] Switching monitors via card reframes to the new monitor
