### PR TITLE
fix: align More info button and limit its hover region

### DIFF
--- a/src/components/geostories/dialog/index.tsx
+++ b/src/components/geostories/dialog/index.tsx
@@ -44,7 +44,7 @@ const GeostoryDialog: React.FC<GeostoryDialogProps> = ({
       <DialogTrigger
         title="More info"
         data-testid={`card-button-${id}`}
-        className="group flex items-center space-x-3 rounded text-xs font-bold focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-green"
+        className="group inline-flex items-center space-x-3 rounded text-xs font-bold focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-green"
       >
         <LuInfo
           className="h-6 w-6 text-white-800 transition-colors group-hover:text-white-500"

--- a/src/components/geostories/dialog/index.tsx
+++ b/src/components/geostories/dialog/index.tsx
@@ -44,10 +44,10 @@ const GeostoryDialog: React.FC<GeostoryDialogProps> = ({
       <DialogTrigger
         title="More info"
         data-testid={`card-button-${id}`}
-        className="group inline-flex items-center space-x-3 rounded text-xs font-bold focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-green"
+        className="group/more-info inline-flex items-center space-x-3 rounded text-xs font-bold focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-green"
       >
         <LuInfo
-          className="h-6 w-6 text-white-800 transition-colors group-hover:text-white-500"
+          className="h-6 w-6 text-white-800 transition-colors group-hover/more-info:text-white-500"
           aria-hidden="true"
         />
         <span>More info</span>

--- a/src/components/geostories/view/index.tsx
+++ b/src/components/geostories/view/index.tsx
@@ -38,7 +38,7 @@ const GeostoriesView: FC<GeostoriesViewProps> = ({ data, geostoryLayers, compari
         <p className="text-sm font-medium text-white-50" data-testid="geostory-description">
           {description}
         </p>
-        <div className="flex w-full justify-end space-y-4">
+        <div className="space-y-4">
           <GeostoryDialog {...data} />
         </div>
       </div>

--- a/src/components/monitors/dialog/index.tsx
+++ b/src/components/monitors/dialog/index.tsx
@@ -32,7 +32,7 @@ const MonitorDialog: React.FC<MonitorDialogProps> = ({
       <DialogTrigger
         title="More info"
         data-testid={`card-button-${id}`}
-        className="group flex items-center space-x-3 rounded text-xs font-bold focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-green"
+        className="group inline-flex items-center space-x-3 rounded text-xs font-bold focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-green"
       >
         <LuInfo
           className="h-6 w-6 text-white-800 transition-colors group-hover:text-white-500"

--- a/src/components/monitors/dialog/index.tsx
+++ b/src/components/monitors/dialog/index.tsx
@@ -32,10 +32,10 @@ const MonitorDialog: React.FC<MonitorDialogProps> = ({
       <DialogTrigger
         title="More info"
         data-testid={`card-button-${id}`}
-        className="group inline-flex items-center space-x-3 rounded text-xs font-bold focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-green"
+        className="group/more-info inline-flex items-center space-x-3 rounded text-xs font-bold focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-green"
       >
         <LuInfo
-          className="h-6 w-6 text-white-800 transition-colors group-hover:text-white-500"
+          className="h-6 w-6 text-white-800 transition-colors group-hover/more-info:text-white-500"
           aria-hidden="true"
         />
         <span>More info</span>


### PR DESCRIPTION
## Summary
- Align the geostory **More info** button to the left, matching the monitors layout (previously right-aligned via `flex w-full justify-end`).
- Change the dialog trigger from `flex` to `inline-flex` in both monitor and geostory dialogs so the hover region matches the icon + text width.

## Why
The **More info** button sat on different sides between monitors and geostories. Its `flex` trigger also stretched full width, so the hover effect fired when hovering empty space / adjacent description, not just the icon or text.

## Changes
- `geostories/view/index.tsx` — drop `flex w-full justify-end`, keep `space-y-4`
- `monitors/dialog/index.tsx` — `flex` → `inline-flex`
- `geostories/dialog/index.tsx` — `flex` → `inline-flex`

## Test plan
- [ ] Monitor and geostory **More info** buttons appear on the same (left) side
- [ ] Hover effect fires only over the icon or "More info" text, not the description or empty space
- [ ] Button still opens the dialog; focus ring intact