### PR TITLE
fix: More info button alignment + replace legend tooltips with titles

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -50,7 +50,11 @@ export default defineConfig({
       // layout (categories filter, featured geostories panel) above
       // `(min-width: 1280px) and (min-height: 820px)`. Pin a taller viewport so the desktop
       // breakpoint is met; the device viewport is spread first, so this override wins.
-      use: { ...devices['Desktop Chrome'], channel: 'chromium', viewport: { width: 1440, height: 900 } },
+      use: {
+        ...devices['Desktop Chrome'],
+        channel: 'chromium',
+        viewport: { width: 1440, height: 900 },
+      },
     },
     // ...(process.env.CI
     //   ? []

--- a/src/components/map/controls/index.tsx
+++ b/src/components/map/controls/index.tsx
@@ -124,7 +124,7 @@ export const Controls: FC<ControlsProps> = ({
         isLoading={isLoadingLocationData}
         isFetching={isFetchingLocationData}
         isMobile={isMobile}
-        className="absolute right-0 top-[-134px]"
+        className="absolute right-0 top-[-56px] sm:top-[-134px]"
       />
 
       <RControl.RZoom
@@ -138,7 +138,7 @@ export const Controls: FC<ControlsProps> = ({
 
       <div
         className={cn({
-          'absolute top-4 flex w-full flex-col items-end justify-end space-y-1.5 sm:top-[-26px]':
+          'absolute top-0 flex w-full flex-col items-end justify-end space-y-1.5 sm:top-[-26px]':
             true,
         })}
       >

--- a/src/components/map/controls/index.tsx
+++ b/src/components/map/controls/index.tsx
@@ -111,7 +111,7 @@ export const Controls: FC<ControlsProps> = ({
   return (
     <div
       className={cn({
-        'absolute right-5 top-1/2 z-40 flex -translate-y-[50%] flex-col space-y-1.5 sm:top-1/2 sm:-translate-y-[50%]':
+        'absolute right-5 top-1/3 z-40 flex -translate-y-[50%] flex-col space-y-1.5 sm:top-1/2 sm:-translate-y-[50%]':
           true,
         [className]: !!className,
       })}

--- a/src/components/map/legend/component.tsx
+++ b/src/components/map/legend/component.tsx
@@ -17,10 +17,17 @@ import LegendTimeseries from './timelime';
 import LayerVisibility from './visibility';
 
 export const Legend: React.FC<{ children?: React.ReactNode }> = ({ children }) => {
-  const [layers] = useSyncLayersSettings();
+  const [layers, setLayers] = useSyncLayersSettings();
   const [compareLayers, setCompareLayers] = useSyncCompareLayersSettings();
 
   const layerId = layers?.[0]?.id;
+
+  const handleOpacity = useCallback(
+    (nexOpacity: number) => {
+      void setLayers((prevState) => [{ ...prevState?.[0], opacity: nexOpacity }]);
+    },
+    [setLayers]
+  );
 
   const { data: compareLayerData } = useLayer(
     { layer_id: compareLayers?.[0]?.id, compare: true },
@@ -84,6 +91,29 @@ export const Legend: React.FC<{ children?: React.ReactNode }> = ({ children }) =
       className="flex w-full flex-col space-y-4 overflow-hidden rounded-b-sm border-gray-600 bg-brand-500 px-4"
       style={{ minWidth: legendWidth }}
     >
+      {/* Primary layer toolbar — mobile only (desktop renders it in the legend trigger) */}
+      <div
+        className="relative flex items-center justify-between space-x-4 text-secondary-500 md:hidden"
+        data-testid="map-legend-item"
+      >
+        <div
+          data-testid="map-legend-item-title"
+          className="line-clamp-2 min-w-0 max-w-[60%] text-xs font-bold"
+          title={layerData?.title}
+        >
+          {layerData?.title}
+        </div>
+        <div
+          className="flex shrink-0 space-x-2 divide-x divide-secondary-800"
+          data-testid="map-legend-item-toolbar"
+        >
+          <div className="flex space-x-2">
+            <OpacitySetting defaultValue={layers?.[0]?.opacity} onChange={handleOpacity} />
+            {!isGeostory && <LayerVisibility />}
+          </div>
+          {!isGeostory && <RemoveLayer className="pl-2" />}
+        </div>
+      </div>
       <ScrollArea className={cn({ 'max-h-[216px]': !isLoadingLayerData })}>
         {isLoadingLayerData ||
           (isLoadingLegendData && (

--- a/src/components/map/legend/component.tsx
+++ b/src/components/map/legend/component.tsx
@@ -88,7 +88,7 @@ export const Legend: React.FC<{ children?: React.ReactNode }> = ({ children }) =
 
   return (
     <div
-      className="flex w-full flex-col space-y-4 overflow-hidden rounded-b-sm border-gray-600 bg-brand-500 px-4"
+      className="flex w-full flex-col space-y-4 overflow-hidden rounded-b-sm border-gray-600 bg-brand-500 px-4 py-4 md:py-0"
       style={{ minWidth: legendWidth }}
     >
       {/* Primary layer toolbar — mobile only (desktop renders it in the legend trigger) */}

--- a/src/components/map/legend/component.tsx
+++ b/src/components/map/legend/component.tsx
@@ -88,7 +88,7 @@ export const Legend: React.FC<{ children?: React.ReactNode }> = ({ children }) =
 
   return (
     <div
-      className="flex w-full flex-col space-y-4 overflow-hidden rounded-b-sm border-gray-600 bg-brand-500 px-4 py-4 md:py-0"
+      className="flex w-full flex-col space-y-4 overflow-hidden border-gray-600 bg-brand-500 px-4 py-4 md:py-0"
       style={{ minWidth: legendWidth }}
     >
       {/* Primary layer toolbar — mobile only (desktop renders it in the legend trigger) */}
@@ -126,7 +126,7 @@ export const Legend: React.FC<{ children?: React.ReactNode }> = ({ children }) =
           isFetchedLegendData && <LegendGraphic dataLayer={layerData} dataLegend={legendData} />}
         {isGeostory && compareLayerData && compareLayers?.[0]?.id !== layerId && (
           <div
-            className="flex w-full flex-col space-y-4 rounded-b-sm border-gray-600 bg-brand-500"
+            className="flex w-full flex-col space-y-4 border-gray-600 bg-brand-500"
             style={{ minWidth: legendWidth }}
           >
             <div

--- a/src/components/map/legend/component.tsx
+++ b/src/components/map/legend/component.tsx
@@ -109,9 +109,9 @@ export const Legend: React.FC<{ children?: React.ReactNode }> = ({ children }) =
         >
           <div className="flex space-x-2">
             <OpacitySetting defaultValue={layers?.[0]?.opacity} onChange={handleOpacity} />
-            {!isGeostory && <LayerVisibility />}
+            <LayerVisibility />
           </div>
-          {!isGeostory && <RemoveLayer className="pl-2" />}
+          <RemoveLayer className="pl-2" />
         </div>
       </div>
       <ScrollArea className={cn({ 'max-h-[216px]': !isLoadingLayerData })}>

--- a/src/components/map/legend/index.tsx
+++ b/src/components/map/legend/index.tsx
@@ -13,7 +13,6 @@ import { useSyncLayersSettings } from '@/hooks/sync-query';
 
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
-import { IconTooltip } from '@/components/ui/tooltip';
 
 import LegendComponent from './component';
 import OpacitySetting from './opacity';
@@ -86,17 +85,16 @@ export const Legend: React.FC<{
                 {!isGeostory && <RemoveLayer className="pl-2" />}
               </div>
             </div>
-            <IconTooltip label={isOpen ? 'Collapse legend' : 'Expand legend'}>
-              <button
-                type="button"
-                data-testid="map-legend-collapse-button"
-                aria-label={isOpen ? 'Collapse legend' : 'Expand legend'}
-                className="flex shrink-0 self-start"
-                onClick={handleCollapse}
-              >
-                <LuChevronDown className="h-6 w-6 text-accent-green transition-colors hover:text-secondary-500 group-data-[state=closed]:rotate-180" />
-              </button>
-            </IconTooltip>
+            <button
+              type="button"
+              data-testid="map-legend-collapse-button"
+              aria-label={isOpen ? 'Collapse legend' : 'Expand legend'}
+              title={isOpen ? 'Collapse legend' : 'Expand legend'}
+              className="flex shrink-0 self-start"
+              onClick={handleCollapse}
+            >
+              <LuChevronDown className="h-6 w-6 text-accent-green transition-colors hover:text-secondary-500 group-data-[state=closed]:rotate-180" />
+            </button>
           </div>
         </CollapsibleTrigger>
         <CollapsibleContent className="hidden sm:block">

--- a/src/components/map/legend/index.tsx
+++ b/src/components/map/legend/index.tsx
@@ -21,7 +21,7 @@ import LayerVisibility from './visibility';
 
 export const Legend: React.FC<{
   isGeostory?: boolean;
-}> = ({ isGeostory = false }) => {
+}> = () => {
   const isMobile = useMediaQuery(mobile);
   const [isOpen, setIsOpen] = useState(true);
 
@@ -80,9 +80,9 @@ export const Legend: React.FC<{
               >
                 <div className="flex space-x-2">
                   <OpacitySetting defaultValue={opacity} onChange={handleOpacity} />
-                  {!isGeostory && <LayerVisibility />}
+                  <LayerVisibility />
                 </div>
-                {!isGeostory && <RemoveLayer className="pl-2" />}
+                <RemoveLayer className="pl-2" />
               </div>
             </div>
             <button

--- a/src/components/map/legend/opacity/index.tsx
+++ b/src/components/map/legend/opacity/index.tsx
@@ -7,7 +7,6 @@ import { cn } from '@/lib/classnames';
 
 import { Slider } from '@/components/slider';
 import { Popover, PopoverArrow, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
-import { IconTooltip } from '@/components/ui/tooltip';
 
 export const OpacitySetting: FC<{
   defaultValue?: number;
@@ -28,16 +27,18 @@ export const OpacitySetting: FC<{
 
   return (
     <Popover onOpenChange={handleOpacityVisibility}>
-      <IconTooltip label="Adjust layer opacity">
-        <PopoverTrigger data-testid="layer-opacity-button" aria-label="Adjust layer opacity">
-          <MdOutlineOpacity
-            className={cn({
-              'h-5 w-5 text-gray-600 transition-colors hover:text-secondary-500': true,
-              'text-secondary-500': isOpacityPopoverOpen,
-            })}
-          />
-        </PopoverTrigger>
-      </IconTooltip>
+      <PopoverTrigger
+        data-testid="layer-opacity-button"
+        aria-label="Adjust layer opacity"
+        title="Adjust layer opacity"
+      >
+        <MdOutlineOpacity
+          className={cn({
+            'h-5 w-5 text-gray-600 transition-colors hover:text-secondary-500': true,
+            'text-secondary-500': isOpacityPopoverOpen,
+          })}
+        />
+      </PopoverTrigger>
       <PopoverContent
         sideOffset={0}
         alignOffset={0}

--- a/src/components/map/legend/remove/index.tsx
+++ b/src/components/map/legend/remove/index.tsx
@@ -27,7 +27,7 @@ export const RemoveLayer: FC<{ className?: string }> = ({ className }) => {
       aria-label="Remove layer"
       title="Remove layer"
     >
-      <LuX className="h-6 w-6 text-gray-600 transition-colors hover:text-secondary-500" />
+      <LuX className="h-5 w-5 text-gray-600 transition-colors hover:text-secondary-500" />
     </button>
   );
 };

--- a/src/components/map/legend/remove/index.tsx
+++ b/src/components/map/legend/remove/index.tsx
@@ -6,8 +6,6 @@ import { cn } from '@/lib/classnames';
 
 import { useSyncLayersSettings, useSyncCompareLayersSettings } from '@/hooks/sync-query';
 
-import { IconTooltip } from '@/components/ui/tooltip';
-
 export const RemoveLayer: FC<{ className?: string }> = ({ className }) => {
   const [, setLayers] = useSyncLayersSettings();
   const [, setCompareLayers] = useSyncCompareLayersSettings();
@@ -18,20 +16,19 @@ export const RemoveLayer: FC<{ className?: string }> = ({ className }) => {
   }, [setLayers, setCompareLayers]);
 
   return (
-    <IconTooltip label="Remove layer">
-      <button
-        data-testid="remove-layer"
-        type="button"
-        className={cn({
-          'flex cursor-pointer items-center justify-center': true,
-          [className]: !!className,
-        })}
-        onClick={handleRemoveLayer}
-        aria-label="Remove layer"
-      >
-        <LuX className="h-6 w-6 text-gray-600 transition-colors hover:text-secondary-500" />
-      </button>
-    </IconTooltip>
+    <button
+      data-testid="remove-layer"
+      type="button"
+      className={cn({
+        'flex cursor-pointer items-center justify-center': true,
+        [className]: !!className,
+      })}
+      onClick={handleRemoveLayer}
+      aria-label="Remove layer"
+      title="Remove layer"
+    >
+      <LuX className="h-6 w-6 text-gray-600 transition-colors hover:text-secondary-500" />
+    </button>
   );
 };
 

--- a/src/components/map/legend/visibility/index.tsx
+++ b/src/components/map/legend/visibility/index.tsx
@@ -7,8 +7,6 @@ import { cn } from '@/lib/classnames';
 
 import { useSyncLayersSettings } from '@/hooks/sync-query';
 
-import { IconTooltip } from '@/components/ui/tooltip';
-
 export const LayerVisibility = () => {
   const [layers, setLayers] = useSyncLayersSettings();
   const layerOpacity = layers?.[0]?.opacity;
@@ -20,32 +18,31 @@ export const LayerVisibility = () => {
   }, [isLayerVisible, setLayers]);
 
   return (
-    <IconTooltip label={isLayerVisible ? 'Hide layer' : 'Show layer'}>
-      <button
-        data-testid="layer-visibility"
-        data-active={isLayerVisible}
-        type="button"
-        className="flex items-center justify-center"
-        onClick={onToggleLayerVisibility}
-        aria-label="Toggle layer visibility"
-      >
-        {isLayerVisible ? (
-          <IoMdEye
-            className={cn({
-              'h-5 w-5 transition-colors hover:text-secondary-500': true,
-              'text-gray-600': !isLayerVisible,
-            })}
-          />
-        ) : (
-          <IoMdEyeOff
-            className={cn({
-              'h-4 w-4 transition-colors hover:text-secondary-500': true,
-              'text-gray-600': !isLayerVisible,
-            })}
-          />
-        )}
-      </button>
-    </IconTooltip>
+    <button
+      data-testid="layer-visibility"
+      data-active={isLayerVisible}
+      type="button"
+      className="flex items-center justify-center"
+      onClick={onToggleLayerVisibility}
+      aria-label="Toggle layer visibility"
+      title={isLayerVisible ? 'Hide layer' : 'Show layer'}
+    >
+      {isLayerVisible ? (
+        <IoMdEye
+          className={cn({
+            'h-5 w-5 transition-colors hover:text-secondary-500': true,
+            'text-gray-600': !isLayerVisible,
+          })}
+        />
+      ) : (
+        <IoMdEyeOff
+          className={cn({
+            'h-4 w-4 transition-colors hover:text-secondary-500': true,
+            'text-gray-600': !isLayerVisible,
+          })}
+        />
+      )}
+    </button>
   );
 };
 

--- a/src/components/map/legend/visibility/index.tsx
+++ b/src/components/map/legend/visibility/index.tsx
@@ -28,7 +28,7 @@ export const LayerVisibility = () => {
       {isLayerVisible ? (
         <IoMdEye className="h-5 w-5 text-gray-600 transition-colors hover:text-secondary-500" />
       ) : (
-        <IoMdEyeOff className="h-4 w-4 text-gray-600 transition-colors hover:text-secondary-500" />
+        <IoMdEyeOff className="h-5 w-5 text-gray-600 transition-colors hover:text-secondary-500" />
       )}
     </button>
   );

--- a/src/components/map/legend/visibility/index.tsx
+++ b/src/components/map/legend/visibility/index.tsx
@@ -3,8 +3,6 @@ import { useCallback, useMemo } from 'react';
 import { IoMdEyeOff } from 'react-icons/io';
 import { IoMdEye } from 'react-icons/io';
 
-import { cn } from '@/lib/classnames';
-
 import { useSyncLayersSettings } from '@/hooks/sync-query';
 
 export const LayerVisibility = () => {
@@ -28,19 +26,9 @@ export const LayerVisibility = () => {
       title={isLayerVisible ? 'Hide layer' : 'Show layer'}
     >
       {isLayerVisible ? (
-        <IoMdEye
-          className={cn({
-            'h-5 w-5 transition-colors hover:text-secondary-500': true,
-            'text-gray-600': !isLayerVisible,
-          })}
-        />
+        <IoMdEye className="h-5 w-5 text-gray-600 transition-colors hover:text-secondary-500" />
       ) : (
-        <IoMdEyeOff
-          className={cn({
-            'h-4 w-4 transition-colors hover:text-secondary-500': true,
-            'text-gray-600': !isLayerVisible,
-          })}
-        />
+        <IoMdEyeOff className="h-4 w-4 text-gray-600 transition-colors hover:text-secondary-500" />
       )}
     </button>
   );

--- a/src/components/timeseries-comparative-layers/index.tsx
+++ b/src/components/timeseries-comparative-layers/index.tsx
@@ -83,11 +83,11 @@ const TimeSeriesComparativeLayers: FC<{
               open={contentVisibility}
               onOpenChange={setContentVisibility}
             >
-              <SelectTrigger className="min-w-0 max-w-[50%] text-xs font-semibold">
+              <SelectTrigger className="min-w-0 max-w-full text-xs font-semibold">
                 <div
                   className={cn(
                     buttonVariants({ variant: 'outline', size: 'sm' }),
-                    'w-full justify-between overflow-hidden hover:bg-transparent'
+                    'w-full justify-between gap-2 overflow-hidden hover:bg-transparent'
                   )}
                   title={currentRange?.label}
                 >

--- a/src/components/timeseries-comparative-layers/index.tsx
+++ b/src/components/timeseries-comparative-layers/index.tsx
@@ -71,7 +71,7 @@ const TimeSeriesComparativeLayers: FC<{
   );
 
   return (
-    <div className="flex w-full flex-col">
+    <div className="flex w-full flex-col py-4">
       {/* Select dates */}
       <div className="flex flex-col space-y-2 text-secondary-500">
         <span className="text-sm">Select date:</span>
@@ -83,7 +83,7 @@ const TimeSeriesComparativeLayers: FC<{
               open={contentVisibility}
               onOpenChange={setContentVisibility}
             >
-              <SelectTrigger className="min-w-0 max-w-full text-xs font-semibold">
+              <SelectTrigger className="w-fit min-w-0 max-w-full text-xs font-semibold">
                 <div
                   className={cn(
                     buttonVariants({ variant: 'outline', size: 'sm' }),

--- a/src/components/timeseries-layer/index.tsx
+++ b/src/components/timeseries-layer/index.tsx
@@ -93,11 +93,11 @@ const TimeSeriesSameLayer: FC<{
               open={contentVisibility}
               onOpenChange={setContentVisibility}
             >
-              <SelectTrigger className="min-w-0 max-w-[50%] text-xs font-semibold">
+              <SelectTrigger className="min-w-0 max-w-full text-xs font-semibold">
                 <div
                   className={cn(
                     buttonVariants({ variant: 'outline', size: 'sm' }),
-                    'w-full justify-between overflow-hidden hover:bg-transparent'
+                    'w-full justify-between gap-2 overflow-hidden hover:bg-transparent'
                   )}
                   title={currentRange?.label}
                 >
@@ -122,7 +122,7 @@ const TimeSeriesSameLayer: FC<{
             </Select>
           )}
           {currentRange && (range?.length ?? 0) === 1 && (
-            <div className="min-w-0 max-w-[50%] text-xs font-semibold">
+            <div className="min-w-0 max-w-full text-xs font-semibold">
               <div
                 className={cn(
                   buttonVariants({ variant: 'outline', size: 'sm' }),
@@ -158,11 +158,11 @@ const TimeSeriesSameLayer: FC<{
                 setContentCompareVisibility((prev) => !prev);
               }}
             >
-              <SelectTrigger className="min-w-0 max-w-[50%] text-xs font-semibold">
+              <SelectTrigger className="min-w-0 max-w-full text-xs font-semibold">
                 <div
                   className={cn(
                     buttonVariants({ variant: 'outline', size: 'sm' }),
-                    'w-full justify-between overflow-hidden hover:bg-transparent'
+                    'w-full justify-between gap-2 overflow-hidden hover:bg-transparent'
                   )}
                   title={compareCurrentRange?.label || range?.[0]?.label}
                 >

--- a/src/components/timeseries-layer/index.tsx
+++ b/src/components/timeseries-layer/index.tsx
@@ -81,7 +81,7 @@ const TimeSeriesSameLayer: FC<{
   const hasAnyCompare = !!compareLayers?.[0]?.id;
 
   return (
-    <div className="flex w-full flex-col">
+    <div className="flex w-full flex-col py-4">
       {/* Select dates */}
       <div className="flex flex-col space-y-2 text-secondary-500">
         <span className="text-sm">Select date:</span>
@@ -93,7 +93,7 @@ const TimeSeriesSameLayer: FC<{
               open={contentVisibility}
               onOpenChange={setContentVisibility}
             >
-              <SelectTrigger className="min-w-0 max-w-full text-xs font-semibold">
+              <SelectTrigger className="w-fit min-w-0 max-w-full text-xs font-semibold">
                 <div
                   className={cn(
                     buttonVariants({ variant: 'outline', size: 'sm' }),
@@ -122,7 +122,7 @@ const TimeSeriesSameLayer: FC<{
             </Select>
           )}
           {currentRange && (range?.length ?? 0) === 1 && (
-            <div className="min-w-0 max-w-full text-xs font-semibold">
+            <div className="w-fit min-w-0 max-w-full text-xs font-semibold">
               <div
                 className={cn(
                   buttonVariants({ variant: 'outline', size: 'sm' }),
@@ -158,7 +158,7 @@ const TimeSeriesSameLayer: FC<{
                 setContentCompareVisibility((prev) => !prev);
               }}
             >
-              <SelectTrigger className="min-w-0 max-w-full text-xs font-semibold">
+              <SelectTrigger className="w-fit min-w-0 max-w-full text-xs font-semibold">
                 <div
                   className={cn(
                     buttonVariants({ variant: 'outline', size: 'sm' }),

--- a/src/containers/explore/toolbar/mobile/nav-bar/index.tsx
+++ b/src/containers/explore/toolbar/mobile/nav-bar/index.tsx
@@ -93,7 +93,7 @@ const MobileExploreNavbar = () => {
             <ScrollArea className="min-h-0 flex-1">
               {isLoading && !isFetched && <Loading />}
               {!isLoading && isFetched && results && (
-                <CardList className="px-6 pb-24" data={results} />
+                <CardList className="px-6 pb-4" data={results} />
               )}
             </ScrollArea>
           </div>

--- a/src/containers/explore/toolbar/mobile/nav-bar/index.tsx
+++ b/src/containers/explore/toolbar/mobile/nav-bar/index.tsx
@@ -51,13 +51,13 @@ const MobileExploreNavbar = () => {
         <div className={cn('relative p-4', showTheme && 'min-h-[calc(100dvh-130px)]')}>
           <div
             className={cn(
-              'absolute inset-0 overflow-hidden transition-all duration-300 ease-in-out',
+              'absolute inset-0 flex flex-col overflow-hidden transition-all duration-300 ease-in-out',
               showTheme
                 ? 'pointer-events-auto z-10 scale-100 opacity-100'
                 : 'pointer-events-none z-0 scale-95 opacity-0'
             )}
           >
-            <header className="sticky">
+            <header className="shrink-0">
               <section className="flex items-center justify-between bg-black-300 px-6 py-2">
                 <Button
                   variant="background"
@@ -90,10 +90,10 @@ const MobileExploreNavbar = () => {
               </section>
             </header>
 
-            <ScrollArea className="h-full">
+            <ScrollArea className="min-h-0 flex-1">
               {isLoading && !isFetched && <Loading />}
               {!isLoading && isFetched && results && (
-                <CardList className="px-6 pb-44" data={results} />
+                <CardList className="px-6 pb-24" data={results} />
               )}
             </ScrollArea>
           </div>

--- a/src/containers/explore/toolbar/mobile/toolbar/index.tsx
+++ b/src/containers/explore/toolbar/mobile/toolbar/index.tsx
@@ -30,12 +30,12 @@ const MobileExploreToolbar: FC<PropsWithChildren> = ({ children }) => {
       >
         {showDetails && (
           <div className={cn('relative  overflow-hidden p-4', showDetails && 'min-h-[80vh]')}>
-            <div className="absolute inset-0 z-10 overflow-hidden pb-[60px]">
-              <header className="sticky flex px-6 pb-2 pt-6">
+            <div className="absolute inset-0 z-10 flex flex-col overflow-hidden">
+              <header className="flex shrink-0 px-6 pb-2 pt-6">
                 <BackToMonitorsAndGeostories />
               </header>
-              <ScrollArea className="h-full">
-                <div className="px-4">{children}</div>
+              <ScrollArea className="min-h-0 flex-1">
+                <div className="px-4 pb-4">{children}</div>
               </ScrollArea>
             </div>
           </div>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -189,7 +189,7 @@
   left: unset !important;
   margin: 0 !important;
   border-radius: 50% !important;
-  @apply !top-[142px] h-[96px] w-[48px] sm:!top-[calc(50%-94px)] sm:h-[68px] sm:w-[34px];
+  @apply !top-[121px] h-[96px] w-[48px] sm:!top-[calc(50%-94px)] sm:h-[68px] sm:w-[34px];
 }
 
 .ol-zoom-in,


### PR DESCRIPTION
## Summary

Cluster of UI fixes for the explore map legend, mobile toolbar/controls, and the More info buttons.

### Legend
- Date selector now fits its own content instead of stretching/truncating (`w-fit` on triggers)
- Removed rounded bottom corners; added vertical padding on mobile
- Show toolbar on mobile, unify icon sizes, consistent hover on visibility icon
- Show layer visibility + remove buttons in geostory legend
- Replaced legend tooltips with native `title` attributes

### Mobile
- Align map controls into a tidy uniform stack without overlap
- Raise controls so expanded legend doesn't cover them
- Catalogue list and monitor detail drawer scroll fully to their end

### More info buttons
- Align geostory More info button left to match monitors
- Scope hover region to icon + text (inline-flex), not the whole sidebar group

### Chore
- Fix prettier formatting in playwright config

## Test plan
- [ ] Legend date selector width matches label, both single + multi-date
- [ ] Mobile map controls stack cleanly, not hidden by legend
- [ ] Catalogue list / monitor drawer scroll to bottom on mobile
- [ ] More info hover limited to icon + text
- [ ] Geostory legend shows visibility + remove controls
