### PR TITLE
test: mock /geostories API to fix flaky landing-page e2e tests

### DIFF
--- a/e2e/fixtures/geostories.ts
+++ b/e2e/fixtures/geostories.ts
@@ -1,0 +1,92 @@
+import type { Page } from '@playwright/test';
+
+import type { Geostory } from '@/types/geostories';
+
+/**
+ * Deterministic geostories fixture for the landing-page e2e tests.
+ *
+ * These tests used to hit the live `/geostories` API, which made them flaky on slow CI
+ * runners (debounce + network round-trip + Cesium globe hydration regularly blew the
+ * test-timeout budget). Mocking the endpoint keeps them fast and deterministic.
+ *
+ * Notes for anyone editing this fixture:
+ * - `id`s must stay within FEATURED_GEOSTORY_IDS or the landing list won't render them.
+ * - `theme` must be a valid category id (CATEGORIES_COLORS[theme] is read while rendering).
+ * - `Water` is intentionally left with no featured geostory so the "no-results when no
+ *   featured geostory matches the selected category" test has an empty category to select.
+ */
+
+export const FEATURED_GEOSTORY_IDS = [
+  'g1',
+  'g2',
+  'g3',
+  'g4',
+  'g5',
+  'g7',
+  'g10',
+  'g11',
+  'g12',
+  'g19',
+  'g21',
+  'g23',
+  'g31',
+  'g32',
+] as const;
+
+const makeGeostory = (id: string, title: string, theme: Geostory['theme']): Geostory => ({
+  id,
+  title,
+  theme,
+  author: 'Test Author',
+  date_created: '2024-01-01',
+  description: `${title} description`,
+  layers: [],
+  entity_type: 'geo_story',
+  ready: true,
+  metadata_url: '',
+  notebooks_url: '',
+  publications: [],
+  use_case_link: [],
+  geostory_bbox: null,
+  monitors: [],
+});
+
+// 14 featured geostories spread across every category except Water (left empty on purpose).
+export const GEOSTORIES_FIXTURE: Geostory[] = [
+  makeGeostory('g1', 'Crop Yield Trends', 'Agriculture'),
+  makeGeostory('g7', 'Irrigated Farmland Change', 'Agriculture'),
+  makeGeostory('g2', 'Heatwave Exposure', 'Climate & Health'),
+  makeGeostory('g10', 'Air Quality and Mortality', 'Climate & Health'),
+  makeGeostory('g3', 'Soil Organic Carbon', 'Soil'),
+  makeGeostory('g11', 'Soil Erosion Risk', 'Soil'),
+  makeGeostory('g21', 'Topsoil Moisture', 'Soil'),
+  makeGeostory('g4', 'Forest Carbon Stocks', 'Forest'),
+  makeGeostory('g12', 'Deforestation Hotspots', 'Forest'),
+  makeGeostory('g31', 'Forest Canopy Height', 'Forest'),
+  makeGeostory('g5', 'Species Richness', 'Biodiversity'),
+  makeGeostory('g19', 'Habitat Connectivity', 'Biodiversity'),
+  makeGeostory('g23', 'Pollinator Distribution', 'Biodiversity'),
+  makeGeostory('g32', 'Protected Area Coverage', 'Biodiversity'),
+];
+
+/**
+ * Intercept the app's `GET /geostories` request and answer from the fixture. Honors the
+ * `title` query param (the search box), filtering by case-insensitive substring match the
+ * same way the backend does, so search tests stay realistic without a live API.
+ */
+export async function mockGeostories(page: Page, geostories: Geostory[] = GEOSTORIES_FIXTURE) {
+  await page.route(/\/geostories(\?.*)?$/, (route) => {
+    const url = new URL(route.request().url());
+    const title = url.searchParams.get('title');
+    const body =
+      title && title.length >= 2
+        ? geostories.filter((g) => g.title.toLowerCase().includes(title.toLowerCase()))
+        : geostories;
+
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(body),
+    });
+  });
+}

--- a/e2e/search.spec.ts
+++ b/e2e/search.spec.ts
@@ -1,21 +1,6 @@
 import { test, expect, type Page } from '@playwright/test';
 
-const FEATURED_GEOSTORY_IDS = [
-  'g1',
-  'g2',
-  'g3',
-  'g4',
-  'g5',
-  'g7',
-  'g10',
-  'g11',
-  'g12',
-  'g19',
-  'g21',
-  'g23',
-  'g31',
-  'g32',
-];
+import { FEATURED_GEOSTORY_IDS, GEOSTORIES_FIXTURE, mockGeostories } from './fixtures/geostories';
 
 /**
  * Wait for the landing page's geostories panel to render — a reliable signal that
@@ -29,6 +14,7 @@ async function waitForLandingReady(page: Page) {
 }
 
 test.beforeEach(async ({ page }) => {
+  await mockGeostories(page);
   await page.goto('/');
 });
 
@@ -89,19 +75,10 @@ test.describe('featured geostories on landing page', () => {
   });
 
   test('filters displayed geostories when searching by title', async ({ page }) => {
-    const API_URL = process.env.NEXT_PUBLIC_API_URL;
-    const response = await page.request.get(`${API_URL}/monitors-and-geostories/`);
-    const data = await response.json();
-
-    // Find a geostory from the featured list in the API response (plain array)
-    const featuredResult = Array.isArray(data)
-      ? data.find((item) => item.id?.startsWith('g') && FEATURED_GEOSTORY_IDS.includes(item.id))
-      : undefined;
-
-    if (!featuredResult) {
-      test.skip(true, 'No featured geostory found in API response to search for');
-      return;
-    }
+    // The fixture's first entry is a featured geostory; its title is unique enough that
+    // the substring search resolves to a single item.
+    const featuredResult = GEOSTORIES_FIXTURE[0];
+    expect((FEATURED_GEOSTORY_IDS as readonly string[]).includes(featuredResult.id)).toBe(true);
 
     await waitForLandingReady(page);
     const searchInput = page.getByTestId('search-input');

--- a/e2e/theme-filter.spec.ts
+++ b/e2e/theme-filter.spec.ts
@@ -2,35 +2,12 @@ import { test, expect, type Page } from '@playwright/test';
 
 import type { Geostory } from '@/types/geostories';
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL;
-
-const FEATURED_GEOSTORY_IDS = [
-  'g1',
-  'g2',
-  'g3',
-  'g4',
-  'g5',
-  'g7',
-  'g10',
-  'g11',
-  'g12',
-  'g19',
-  'g21',
-  'g23',
-  'g31',
-  'g32',
-];
-
-async function fetchGeostories(page: Page): Promise<Geostory[]> {
-  if (!API_URL) throw new Error('NEXT_PUBLIC_API_URL is not set');
-  const response = await page.request.get(`${API_URL}/geostories`);
-  if (!response.ok()) throw new Error(`Failed to fetch geostories: ${response.status()}`);
-  return response.json();
-}
+import { FEATURED_GEOSTORY_IDS, GEOSTORIES_FIXTURE, mockGeostories } from './fixtures/geostories';
 
 function featuredForCategories(geostories: Geostory[], categories: string[]) {
   return geostories.filter(
-    (g) => FEATURED_GEOSTORY_IDS.includes(g.id) && categories.includes(g.theme)
+    (g) =>
+      (FEATURED_GEOSTORY_IDS as readonly string[]).includes(g.id) && categories.includes(g.theme)
   );
 }
 
@@ -49,6 +26,7 @@ async function waitForLandingReady(page: Page) {
 }
 
 test.beforeEach(async ({ page }) => {
+  await mockGeostories(page);
   await page.goto('/', { waitUntil: 'load' });
 });
 
@@ -80,7 +58,7 @@ test.describe('category filters on landing page', () => {
   });
 
   test('selecting one category filters the list and updates the URL', async ({ page }) => {
-    const allGeostories = await fetchGeostories(page);
+    const allGeostories = GEOSTORIES_FIXTURE;
     const category = 'Forest';
 
     await waitForLandingReady(page);
@@ -102,7 +80,7 @@ test.describe('category filters on landing page', () => {
   });
 
   test('selecting multiple categories is accumulative and updates the URL', async ({ page }) => {
-    const allGeostories = await fetchGeostories(page);
+    const allGeostories = GEOSTORIES_FIXTURE;
     const categories = ['Soil', 'Water'];
 
     await waitForLandingReady(page);
@@ -148,7 +126,7 @@ test.describe('category filters on landing page', () => {
   test('selecting three categories shows only matching featured geostories and all are in the URL', async ({
     page,
   }) => {
-    const allGeostories = await fetchGeostories(page);
+    const allGeostories = GEOSTORIES_FIXTURE;
     const categories = ['Forest', 'Agriculture', 'Biodiversity'];
 
     await waitForLandingReady(page);
@@ -176,7 +154,7 @@ test.describe('category filters on landing page', () => {
   test('no-results message shown when no featured geostory matches the selected category', async ({
     page,
   }) => {
-    const allGeostories = await fetchGeostories(page);
+    const allGeostories = GEOSTORIES_FIXTURE;
 
     const allCategories = [
       'Agriculture',


### PR DESCRIPTION
## Summary

The landing-page e2e tests (`search.spec.ts`, `theme-filter.spec.ts`) hit the **live `/geostories` API** with no mocks. On slow CI runners the debounce + network round-trip + Cesium globe hydration regularly blew the test-timeout budget — pure `TimeoutError`s, not assertion failures. They pass locally (~12s) but flaked on CI.

This mocks `GET /geostories` deterministically.

### Changes
- New `e2e/fixtures/geostories.ts`: shared `GEOSTORIES_FIXTURE` (14 featured geostories across all categories), `FEATURED_GEOSTORY_IDS`, and a `mockGeostories(page)` helper that intercepts `/geostories` and honors the `title` search param.
- `search.spec.ts` + `theme-filter.spec.ts`: mock the API in `beforeEach`; derive expectations from the fixture instead of live `page.request.get(...)` calls.
- `Water` is intentionally left with no featured geostory so the "no-results category" test runs deterministically (was conditionally skipped before).

No app code changed — test-only.

## Test plan
- [x] `yarn test e2e/search.spec.ts e2e/theme-filter.spec.ts` — 11 passed locally (~10s, was 30–60s+ on CI)
- [x] `yarn check-types` clean
- [x] `yarn lint` clean on changed files
- [ ] CI green on Chromium
