### PR TITLE
feat: improve SEO with metadata, sitemap, robots, OG cards and JSON-LD

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,2 +1,0 @@
-User-agent: *
-Disallow: /

--- a/src/app/(landing)/layout.tsx
+++ b/src/app/(landing)/layout.tsx
@@ -1,16 +1,6 @@
-import { Metadata } from 'next';
-
 import Header from '@/components/header';
 
 import { GlobeLayoutResponsive } from './globe-layout-responsive';
-
-export const metadata: Metadata = {
-  title:
-    'Open-Earth-Monitor project – A cyberinfrastructure to accelerate uptake of environmental information',
-  keywords: ['Open Earth Monitor', 'Cyberinfrastructure', 'Geostories', 'Monitors'],
-  description:
-    'It supports sustainable land management, ecological monitoring, and spatial modeling through standardized, ready-to-use geospatial layers. The most extensive version of the data is hosted on OpenLandMap.org, while a selection of layers that can support on-the-ground activities / serving specific OEMC use-cases and partner organizations, will be made available in combination with other layers from Tier 2 stream.',
-};
 
 export default function GlobeLayout({ children }: { children: React.ReactNode }) {
   return (

--- a/src/app/(landing)/page.tsx
+++ b/src/app/(landing)/page.tsx
@@ -3,9 +3,10 @@ import type { Metadata } from 'next';
 import GlobeClient from '@/app/(landing)/client';
 
 export const metadata: Metadata = {
-  title: 'Hub - Open Earth Monitor Cyberinfrastructure',
+  title: 'Hub',
   description:
     'Open Earth Monitor Cyberinfrastructure is an ecosystem of actors creating and using data tools in support of the sustainable environmental policy.',
+  alternates: { canonical: '/' },
 };
 
 export default function GlobePage() {

--- a/src/app/disclaimer/page.tsx
+++ b/src/app/disclaimer/page.tsx
@@ -1,6 +1,13 @@
-import type { NextPage } from 'next';
+import type { Metadata, NextPage } from 'next';
 
 import Header from '@/components/header';
+
+export const metadata: Metadata = {
+  title: 'Disclaimer',
+  description:
+    'Legal disclaimer for the Open Earth Monitor Cyberinfrastructure. Funded by the European Union; data provided “as is” without warranties of any kind.',
+  alternates: { canonical: '/disclaimer' },
+};
 
 const DisclaimerPage: NextPage = () => {
   return (

--- a/src/app/explore/geostory/[geostory_id]/page.tsx
+++ b/src/app/explore/geostory/[geostory_id]/page.tsx
@@ -1,8 +1,14 @@
+import { cache } from 'react';
+
 import type { Metadata } from 'next';
 
 import axios from 'axios';
 
+import { SITE_NAME, absoluteUrl, serializeJsonLd, truncateForMeta } from '@/lib/seo';
+
 import type { Geostory } from '@/types/geostories';
+
+import { getGeostoryImageUrl } from '@/hooks/geostories';
 
 import GeostoryPageComponent from '@/components/geostories/page';
 
@@ -10,24 +16,75 @@ type Props = {
   params: Promise<{ geostory_id: string }>;
 };
 
+// Cached so generateMetadata and the page render share a single request.
+const getGeostory = cache(async (geostoryId: string): Promise<Geostory | null> => {
+  try {
+    const { data } = await axios.get<Geostory[]>(
+      `${process.env.NEXT_PUBLIC_API_URL}/geostories?geostory_id=${geostoryId}`
+    );
+    return data?.[0] ?? null;
+  } catch {
+    return null;
+  }
+});
+
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { geostory_id } = await params;
-  try {
-    const geostoryData = await axios
-      .get<Geostory[]>(`${process.env.NEXT_PUBLIC_API_URL}/geostories?geostory_id=${geostory_id}`)
-      .then((r) => r.data);
+  const geostory = await getGeostory(geostory_id);
 
-    if (!geostoryData?.length) return { title: 'Geostory not found' };
+  if (!geostory) return { title: 'Geostory not found' };
 
-    return {
-      title: `${geostoryData[0].title} - Open Earth Monitor Cyberinfrastructure`,
-    };
-  } catch {
-    return { title: 'Geostory' };
-  }
+  const canonical = `/explore/geostory/${geostory_id}`;
+  const description = truncateForMeta(geostory.description);
+  const image = getGeostoryImageUrl(geostory.id);
+
+  return {
+    title: geostory.title,
+    description,
+    alternates: { canonical },
+    openGraph: {
+      type: 'article',
+      siteName: SITE_NAME,
+      title: geostory.title,
+      description,
+      url: absoluteUrl(canonical),
+      images: [{ url: image, alt: geostory.title }],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: geostory.title,
+      description,
+      images: [image],
+    },
+  };
 }
 
 export default async function ExploreGeostoryMapPage({ params }: Props) {
   const { geostory_id } = await params;
-  return <GeostoryPageComponent geostory_id={geostory_id} />;
+  const geostory = await getGeostory(geostory_id);
+
+  const jsonLd = geostory && {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: geostory.title,
+    description: truncateForMeta(geostory.description, 5000),
+    url: absoluteUrl(`/explore/geostory/${geostory_id}`),
+    image: getGeostoryImageUrl(geostory.id),
+    ...(geostory.author && { author: { '@type': 'Person', name: geostory.author } }),
+    ...(geostory.date_created && { datePublished: geostory.date_created }),
+    publisher: { '@type': 'Organization', name: SITE_NAME },
+  };
+
+  return (
+    <>
+      {jsonLd && (
+        <script
+          type="application/ld+json"
+          // eslint-disable-next-line react/no-danger
+          dangerouslySetInnerHTML={{ __html: serializeJsonLd(jsonLd) }}
+        />
+      )}
+      <GeostoryPageComponent geostory_id={geostory_id} />
+    </>
+  );
 }

--- a/src/app/explore/layout.tsx
+++ b/src/app/explore/layout.tsx
@@ -9,6 +9,7 @@ import { SidebarProvider } from '@/components/ui/sidebar';
 export const metadata: Metadata = {
   title: 'Explore',
   description: 'Explore our Monitors & Geostories',
+  alternates: { canonical: '/explore' },
 };
 
 export default function ExploreLayout({ children }: { children: React.ReactNode }) {

--- a/src/app/explore/layout.tsx
+++ b/src/app/explore/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next';
 
 import Header from '@/components/header';
 import MainMenuDesktop from '@/components/main-menu/desktop';
-import Map from '@/components/map/index';
+import Map from '@/components/map/dynamic';
 import SidebarWrapper from '@/components/sidebar-wrapper';
 import { SidebarProvider } from '@/components/ui/sidebar';
 

--- a/src/app/explore/monitor/[monitor_id]/page.tsx
+++ b/src/app/explore/monitor/[monitor_id]/page.tsx
@@ -1,6 +1,10 @@
+import { cache } from 'react';
+
 import type { Metadata } from 'next';
 
 import axios from 'axios';
+
+import { SITE_NAME, absoluteUrl, serializeJsonLd, truncateForMeta } from '@/lib/seo';
 
 import type { Monitor } from '@/types/monitors';
 
@@ -10,24 +14,72 @@ type Props = {
   params: Promise<{ monitor_id: string }>;
 };
 
+// Cached so generateMetadata and the page render share a single request.
+const getMonitor = cache(async (monitorId: string): Promise<Monitor | null> => {
+  try {
+    const { data } = await axios.get<Monitor[]>(
+      `${process.env.NEXT_PUBLIC_API_URL}/monitors/monitor_id=${monitorId}`
+    );
+    return data?.[0] ?? null;
+  } catch {
+    return null;
+  }
+});
+
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { monitor_id } = await params;
-  try {
-    const monitorData = await axios
-      .get<Monitor[]>(`${process.env.NEXT_PUBLIC_API_URL}/monitors/monitor_id=${monitor_id}`)
-      .then((response) => response.data);
+  const monitor = await getMonitor(monitor_id);
 
-    if (!monitorData?.length) return { title: 'Monitor not found' };
+  if (!monitor) return { title: 'Monitor not found' };
 
-    return {
-      title: `${monitorData[0].title} - Open Earth Monitor Cyberinfrastructure`,
-    };
-  } catch {
-    return { title: 'Monitor' };
-  }
+  const canonical = `/explore/monitor/${monitor_id}`;
+  const description = truncateForMeta(monitor.description);
+
+  return {
+    title: monitor.title,
+    description,
+    alternates: { canonical },
+    openGraph: {
+      type: 'article',
+      siteName: SITE_NAME,
+      title: monitor.title,
+      description,
+      url: absoluteUrl(canonical),
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: monitor.title,
+      description,
+    },
+  };
 }
 
 export default async function ExploreMonitorMapPage({ params }: Props) {
   const { monitor_id } = await params;
-  return <MonitorPageComponent monitor_id={monitor_id} />;
+  const monitor = await getMonitor(monitor_id);
+
+  const jsonLd = monitor && {
+    '@context': 'https://schema.org',
+    '@type': 'Dataset',
+    name: monitor.title,
+    description: truncateForMeta(monitor.description, 5000),
+    url: absoluteUrl(`/explore/monitor/${monitor_id}`),
+    ...(monitor.author && { creator: { '@type': 'Organization', name: monitor.author } }),
+    ...(monitor.date_created && { dateCreated: monitor.date_created }),
+    ...(monitor.coverage && { spatialCoverage: monitor.coverage }),
+    isAccessibleForFree: true,
+  };
+
+  return (
+    <>
+      {jsonLd && (
+        <script
+          type="application/ld+json"
+          // eslint-disable-next-line react/no-danger
+          dangerouslySetInnerHTML={{ __html: serializeJsonLd(jsonLd) }}
+        />
+      )}
+      <MonitorPageComponent monitor_id={monitor_id} />
+    </>
+  );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,15 @@ import { Metadata } from 'next';
 import { Inter } from 'next/font/google';
 import localFont from 'next/font/local';
 
+import {
+  SITE_URL,
+  SITE_NAME,
+  DEFAULT_TITLE,
+  DEFAULT_DESCRIPTION,
+  absoluteUrl,
+  serializeJsonLd,
+} from '@/lib/seo';
+
 import Providers from '@/utils/providers';
 
 // Styles
@@ -21,11 +30,52 @@ const inter = Inter({
 });
 
 export const metadata: Metadata = {
-  title:
-    'Open-Earth-Monitor project – A cyberinfrastructure to accelerate uptake of environmental information',
+  metadataBase: new URL(SITE_URL),
+  title: {
+    default: DEFAULT_TITLE,
+    template: `%s | ${SITE_NAME}`,
+  },
   keywords: ['Open Earth Monitor', 'Cyberinfrastructure', 'Geostories', 'Monitors'],
-  description:
-    'It supports sustainable land management, ecological monitoring, and spatial modeling through standardized, ready-to-use geospatial layers. The most extensive version of the data is hosted on OpenLandMap.org, while a selection of layers that can support on‑the‑ground activities / serving specific OEMC use‑cases and partner organizations, will be made available in combination with other layers from Tier 2 stream.',
+  description: DEFAULT_DESCRIPTION,
+  applicationName: SITE_NAME,
+  alternates: {
+    canonical: '/',
+  },
+  openGraph: {
+    type: 'website',
+    siteName: SITE_NAME,
+    title: DEFAULT_TITLE,
+    description: DEFAULT_DESCRIPTION,
+    url: SITE_URL,
+    locale: 'en_US',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: DEFAULT_TITLE,
+    description: DEFAULT_DESCRIPTION,
+  },
+};
+
+const jsonLd = {
+  '@context': 'https://schema.org',
+  '@graph': [
+    {
+      '@type': 'Organization',
+      '@id': absoluteUrl('/#organization'),
+      name: SITE_NAME,
+      url: SITE_URL,
+      description: DEFAULT_DESCRIPTION,
+    },
+    {
+      '@type': 'WebSite',
+      '@id': absoluteUrl('/#website'),
+      name: SITE_NAME,
+      url: SITE_URL,
+      description: DEFAULT_DESCRIPTION,
+      inLanguage: 'en',
+      publisher: { '@id': absoluteUrl('/#organization') },
+    },
+  ],
 };
 
 const satoshi = localFont({
@@ -59,6 +109,11 @@ export default function RootLayout({ children }) {
   return (
     <html lang="en" className={`${satoshi.variable} ${inter.variable}`}>
       <body className="mx-auto min-h-screen overflow-x-hidden bg-black-500 font-inter">
+        <script
+          type="application/ld+json"
+          // eslint-disable-next-line react/no-danger
+          dangerouslySetInnerHTML={{ __html: serializeJsonLd(jsonLd) }}
+        />
         <a
           href="#main-content"
           className="sr-only focus:not-sr-only focus:absolute focus:left-2 focus:top-2 focus:z-[9999] focus:rounded focus:bg-accent-green focus:px-4 focus:py-2 focus:text-sm focus:font-medium focus:text-black-500 focus:outline-none"

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -1,0 +1,53 @@
+import { ImageResponse } from 'next/og';
+
+import { SITE_NAME } from '@/lib/seo';
+
+export const alt = SITE_NAME;
+export const size = { width: 1200, height: 630 };
+export const contentType = 'image/png';
+
+export default function OpengraphImage() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'center',
+          padding: '80px',
+          backgroundColor: '#0a0a0a',
+          backgroundImage:
+            'radial-gradient(circle at 0% 0%, rgba(30,237,191,0.25), transparent 45%), radial-gradient(circle at 100% 100%, rgba(117,161,255,0.25), transparent 45%)',
+        }}
+      >
+        <div
+          style={{
+            fontSize: 34,
+            color: '#1EEDBF',
+            letterSpacing: 4,
+            textTransform: 'uppercase',
+            fontWeight: 700,
+          }}
+        >
+          Open Earth Monitor
+        </div>
+        <div
+          style={{
+            marginTop: 24,
+            fontSize: 72,
+            lineHeight: 1.1,
+            fontWeight: 800,
+            color: '#ffffff',
+            maxWidth: 1000,
+          }}
+        >
+          A cyberinfrastructure to accelerate uptake of environmental information
+        </div>
+        <div style={{ marginTop: 40, fontSize: 28, color: '#75A1FF' }}>earthmonitor.org</div>
+      </div>
+    ),
+    { ...size }
+  );
+}

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,14 @@
+import type { MetadataRoute } from 'next';
+
+import { SITE_URL, absoluteUrl } from '@/lib/seo';
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+    },
+    sitemap: absoluteUrl('/sitemap.xml'),
+    host: SITE_URL,
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,60 @@
+import type { MetadataRoute } from 'next';
+
+import axios from 'axios';
+
+import { absoluteUrl } from '@/lib/seo';
+
+import type { Geostory } from '@/types/geostories';
+import type { Monitor } from '@/types/monitors';
+
+// Revalidate the sitemap daily so newly published monitors/geostories appear.
+export const revalidate = 86400;
+
+const STATIC_ROUTES: MetadataRoute.Sitemap = [
+  { url: absoluteUrl('/'), changeFrequency: 'weekly', priority: 1 },
+  { url: absoluteUrl('/explore'), changeFrequency: 'weekly', priority: 0.9 },
+  { url: absoluteUrl('/disclaimer'), changeFrequency: 'yearly', priority: 0.2 },
+  { url: absoluteUrl('/usage-stats'), changeFrequency: 'weekly', priority: 0.3 },
+];
+
+const toLastModified = (date?: string): Date | undefined => {
+  if (!date) return undefined;
+  const parsed = new Date(date);
+  return Number.isNaN(parsed.getTime()) ? undefined : parsed;
+};
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL;
+
+  let monitors: Monitor[] = [];
+  let geostories: Geostory[] = [];
+
+  if (apiUrl) {
+    try {
+      const [monitorsRes, geostoriesRes] = await Promise.allSettled([
+        axios.get<Monitor[]>(`${apiUrl}/monitors`),
+        axios.get<Geostory[]>(`${apiUrl}/geostories`),
+      ]);
+      if (monitorsRes.status === 'fulfilled') monitors = monitorsRes.value.data ?? [];
+      if (geostoriesRes.status === 'fulfilled') geostories = geostoriesRes.value.data ?? [];
+    } catch {
+      // Network failure: fall back to static routes only rather than failing the build.
+    }
+  }
+
+  const monitorRoutes: MetadataRoute.Sitemap = monitors.map((monitor) => ({
+    url: absoluteUrl(`/explore/monitor/${monitor.id}`),
+    lastModified: toLastModified(monitor.date_created),
+    changeFrequency: 'weekly',
+    priority: 0.8,
+  }));
+
+  const geostoryRoutes: MetadataRoute.Sitemap = geostories.map((geostory) => ({
+    url: absoluteUrl(`/explore/geostory/${geostory.id}`),
+    lastModified: toLastModified(geostory.date_created),
+    changeFrequency: 'weekly',
+    priority: 0.7,
+  }));
+
+  return [...STATIC_ROUTES, ...monitorRoutes, ...geostoryRoutes];
+}

--- a/src/app/usage-stats/page.tsx
+++ b/src/app/usage-stats/page.tsx
@@ -1,8 +1,15 @@
-import type { NextPage } from 'next';
+import type { Metadata, NextPage } from 'next';
 
 import LiveUpdatesContent from '@/containers/live-updates';
 
 import Header from '@/components/header';
+
+export const metadata: Metadata = {
+  title: 'Live Updates',
+  description:
+    'Live usage statistics and activity updates for the Open Earth Monitor Cyberinfrastructure platform.',
+  alternates: { canonical: '/usage-stats' },
+};
 
 const UsageStatsPage: NextPage = () => {
   return (

--- a/src/components/map/dynamic.tsx
+++ b/src/components/map/dynamic.tsx
@@ -1,0 +1,10 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+
+// OpenLayers / rlayers touch `document` at render time, so the map must never be
+// server-rendered. Loading it client-only avoids the SSR "document is not defined"
+// crash and the resulting client-render fallback.
+const Map = dynamic(() => import('@/components/map/index'), { ssr: false });
+
+export default Map;

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,0 +1,43 @@
+/**
+ * Centralized SEO configuration and helpers.
+ *
+ * The canonical site URL is environment-driven so staging and production can
+ * each advertise their own absolute URLs (metadataBase, canonicals, sitemap,
+ * Open Graph). Set `NEXT_PUBLIC_SITE_URL` per environment; the fallback is the
+ * current dev deployment.
+ */
+
+export const SITE_URL = (
+  process.env.NEXT_PUBLIC_SITE_URL || 'https://app-dev.earthmonitor.org'
+).replace(/\/$/, '');
+
+export const SITE_NAME = 'Open Earth Monitor Cyberinfrastructure';
+
+export const DEFAULT_TITLE =
+  'Open-Earth-Monitor project – A cyberinfrastructure to accelerate uptake of environmental information';
+
+export const DEFAULT_DESCRIPTION =
+  'It supports sustainable land management, ecological monitoring, and spatial modeling through standardized, ready-to-use geospatial layers. The most extensive version of the data is hosted on OpenLandMap.org, while a selection of layers that can support on‑the‑ground activities / serving specific OEMC use‑cases and partner organizations, will be made available in combination with other layers from Tier 2 stream.';
+
+/** Build an absolute URL from a site-relative path. */
+export const absoluteUrl = (path = '/'): string =>
+  `${SITE_URL}${path.startsWith('/') ? path : `/${path}`}`;
+
+/**
+ * Serialize an object to a JSON-LD string safe to embed in a <script> tag.
+ * Escaping `<` prevents a `</script>` sequence in the data from breaking out
+ * of the script element (the main XSS vector for inline JSON-LD).
+ */
+export const serializeJsonLd = (data: unknown): string =>
+  JSON.stringify(data).replace(/</g, '\\u003c');
+
+/**
+ * Trim a (possibly long, possibly HTML-ish) string to a meta-description-safe
+ * length, collapsing whitespace and adding an ellipsis when truncated.
+ */
+export const truncateForMeta = (text: string | undefined | null, max = 160): string => {
+  if (!text) return DEFAULT_DESCRIPTION;
+  const clean = text.replace(/\s+/g, ' ').trim();
+  if (clean.length <= max) return clean;
+  return `${clean.slice(0, max - 1).trimEnd()}…`;
+};


### PR DESCRIPTION
## Summary

Audits and improves SEO across the OEMC platform. The site was previously **blocked from all search engines** (`robots.txt` had `Disallow: /`) and had no sitemap, Open Graph cards, canonical URLs, or structured data. This PR fixes the crawl-blocking issue and adds a full metadata layer.

Scope: core SEO (no Core Web Vitals / image-optimization changes — deferred to a separate PR to avoid risk to the globe/map assets).

## Changes

- **Unblock crawlers** — replace the blocking `public/robots.txt` with a dynamic `app/robots.ts` that allows crawling and advertises the sitemap.
- **Sitemap** — `app/sitemap.ts` lists static routes plus all monitors and geostories fetched from the API, with `lastModified` from `date_created`. Daily revalidate; falls back to static routes if the API is unreachable (build never fails).
- **Root metadata** — `metadataBase`, title template (`%s | Open Earth Monitor Cyberinfrastructure`), Open Graph + Twitter card defaults, canonical alternates, and `Organization` + `WebSite` JSON-LD.
- **Open Graph image** — branded card generated via `next/og` (`app/opengraph-image.tsx`); no binary asset committed.
- **Detail pages** — monitor and geostory pages now emit `description`, canonical, OG/Twitter metadata, and `Dataset`/`Article` JSON-LD. `generateMetadata` and the page render share a single cached API fetch.
- **Geostory OG image** — uses the existing geostory cover image (`getGeostoryImageUrl`).
- **Static pages** — added metadata to `/disclaimer` and `/usage-stats`; deduped redundant landing metadata.
- **Central config** — `src/lib/seo.ts` holds the env-driven site URL, shared constants, a meta-description truncator, and a `</script>`-safe JSON-LD serializer.

## Configuration

Canonical site URL is env-driven: `NEXT_PUBLIC_SITE_URL`, falling back to `https://app-dev.earthmonitor.org`.

⚠️ **Set `NEXT_PUBLIC_SITE_URL` to the real production domain in the prod environment** — otherwise prod will advertise the dev domain as canonical.

## Test plan

- [x] `yarn build` succeeds; `/robots.txt`, `/sitemap.xml`, `/opengraph-image` routes generated
- [x] `yarn check-types` clean
- [x] `yarn lint` clean (only pre-existing generated `next-env.d.ts` flagged)
- [ ] Verify `/robots.txt` allows crawling and links the sitemap on the deployed env
- [ ] Verify `/sitemap.xml` lists monitors + geostories on the deployed env (needs API reachable)
- [ ] Validate OG cards (`/opengraph-image`, a geostory, a monitor) in a social-card debugger
- [ ] Validate JSON-LD with Google Rich Results Test
- [ ] Confirm `NEXT_PUBLIC_SITE_URL` set per environment

## Deferred

- `images.unoptimized: false` flip + Core Web Vitals — separate PR (risk to globe/map assets).
- Optional: swap the generated OG card for a designed PNG.
