### PR TITLE
fix(OEMC-442): repair Plausible ingestion and add custom interaction events

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,13 @@ Set the environment variables needed creating a file `.env.local` in the root of
 |-|-|-|
 | NEXT_PUBLIC_API_URL | URL of the API for datasets Data. | http://localhost:3000 | 
 
+## Analytics
+
+The platform reports pageviews and custom interaction events to a self-hosted
+Plausible instance. See [docs/analytics.md](./docs/analytics.md) for the event
+catalogue, the props each event carries, and the dashboard configuration needed
+to make those props visible.
+
 ## Contributing
 
 Please, **create a PR** for any improvement or feature you want to add. Try not to commit anything directly on the `main` branch.

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -1,0 +1,325 @@
+# Analytics
+
+The platform uses a **self-hosted Plausible** instance at
+`https://plausible.earthmonitor.org` for both automatic and custom analytics.
+
+- [Setup](#setup)
+- [Automatic tracking](#automatic-tracking)
+- [Custom events](#custom-events)
+- [Event sources](#event-sources)
+- [Adding a new event](#adding-a-new-event)
+- [Conventions and gotchas](#conventions-and-gotchas)
+- [Relationship to `/usage-stats`](#relationship-to-usage-stats)
+
+## Setup
+
+Plausible is wired up in `src/utils/providers.tsx` via
+[`next-plausible`](https://github.com/4lejandrito/next-plausible):
+
+```tsx
+<PlausibleProvider
+  domain="app.earthmonitor.org"
+  trackOutboundLinks
+  trackFileDownloads
+  selfHosted
+  scriptProps={{
+    src: 'https://plausible.earthmonitor.org/js/script.file-downloads.hash.outbound-links.pageview-props.tagged-events.js',
+  }}
+>
+```
+
+Two things about this block are easy to get wrong:
+
+- **`domain` must be a bare hostname.** `next-plausible` passes the prop
+  straight through to the script's `data-domain` attribute, and Plausible
+  matches that value against the domain registered in the dashboard, which is
+  stored without a protocol or trailing slash. A value like
+  `https://app.earthmonitor.org/` silently drops every event — the script loads,
+  requests fire, and nothing is ever attributed.
+- **`scriptProps.src` overrides the computed URL.** `next-plausible` normally
+  derives the script filename from the boolean props, but anything in
+  `scriptProps` is spread last and wins. The hardcoded URL above must therefore
+  already include every extension the app relies on:
+  `file-downloads`, `hash`, `outbound-links`, `pageview-props`, `tagged-events`.
+  Adding a prop like `revenue` without also updating this URL would have no
+  effect.
+
+### When events are sent
+
+`PlausibleProvider` is enabled by default only when
+`NODE_ENV === 'production'` and `NEXT_PUBLIC_VERCEL_ENV` is either unset or
+`'production'`. This project deploys via Docker, so the Vercel variable is
+unset and a production build always tracks. **Nothing is sent from `yarn dev`.**
+
+To verify events locally, add `trackLocalhost` to the provider temporarily —
+don't commit it, or local development will pollute production stats.
+
+## Automatic tracking
+
+Handled by the Plausible script itself, no application code involved:
+
+| What | Source |
+| --- | --- |
+| Pageviews | Core script |
+| Outbound link clicks | `trackOutboundLinks` |
+| File downloads | `trackFileDownloads` |
+
+## Custom events
+
+All custom events go through one typed helper, `src/lib/analytics.ts`:
+
+```tsx
+import { useTrackEvent } from '@/lib/analytics';
+
+const track = useTrackEvent();
+
+track('Geostory Open', {
+  props: { geostory_id: id, title, source: 'geostories-page' },
+});
+```
+
+`useTrackEvent` is `usePlausible<AnalyticsEvents>()`. Because the event map is
+passed as the type parameter, **both the event name and its props are checked at
+the call site** — a typo in a name, a missing prop, or a wrong `source` value is
+a build error rather than a silently malformed event.
+
+Every event and its properties are declared in the `AnalyticsEvents` type. That
+type is the single source of truth; the table below mirrors it.
+
+### `Geostory Open`
+
+A user navigated into a geostory.
+
+| Prop | Type |
+| --- | --- |
+| `geostory_id` | `string` |
+| `title` | `string` |
+| `source` | [`EventSource`](#event-sources) |
+
+Fired from seven places — every entry point into a geostory:
+
+| File | Surface |
+| --- | --- |
+| `containers/globe/geostories/geostories-list/item.tsx` | Landing globe geostory list |
+| `components/globe/geostory-dialog.tsx` | Landing globe dialog, arrow button |
+| `components/geostories/item/index.tsx` | Geostories page card |
+| `components/monitors/table/item/geostory.tsx` | A monitor's expandable geostory sublist |
+| `components/sidebar/card-header.tsx` | Explore sidebar, card title link |
+| `components/sidebar/card-geostory-content.tsx` | Explore sidebar, "Go to geostory" |
+| `components/sidebar/card-monitor-content.tsx` | Explore sidebar, "Related geostories" |
+
+The last three live in the same sidebar card but are separate `<Link>`s — a
+click on the chevron never runs the card header's handler, so each needs its
+own call.
+
+### `Monitor Open`
+
+A user navigated into a monitor.
+
+| Prop | Type |
+| --- | --- |
+| `monitor_id` | `string` |
+| `title` | `string` |
+| `source` | [`EventSource`](#event-sources) |
+
+| File | Surface |
+| --- | --- |
+| `components/monitors/table/item/monitor.tsx` | Monitors page link |
+| `components/sidebar/card-header.tsx` | Explore sidebar, card title link |
+| `components/sidebar/card-monitor-content.tsx` | Explore sidebar, "Go to monitor" |
+
+### `Layer Activate`
+
+A dataset layer was switched **on**. Deactivation is deliberately not tracked —
+turning a layer off is not an interest signal and only adds noise to the
+breakdown.
+
+| Prop | Type |
+| --- | --- |
+| `layer_id` | `string` |
+| `title` | `string` |
+| `parent_type` | `'monitor' \| 'geostory'` |
+
+Fired from `components/datasets/card/index.tsx`, inside the activation branch of
+`handleToggleLayer`.
+
+### `Category Filter`
+
+A category (theme) was **selected**. Clearing a category is not tracked, so the
+breakdown reads as interest per category rather than raw toggle volume.
+
+| Prop | Type |
+| --- | --- |
+| `category` | `CategoryId \| 'All'` |
+| `source` | [`EventSource`](#event-sources) |
+
+| File | Surface |
+| --- | --- |
+| `containers/globe/filters/item.tsx` | Landing globe category pills (multi-select) |
+| `components/theme-filter/map-sidebar-item.tsx` | Explore sidebar icon rail (single-select, plus "All") |
+| `containers/globe/mobile-toolbar.tsx` | Landing mobile toolbar |
+| `containers/explore/toolbar/mobile/nav-bar/index.tsx` | Explore mobile nav bar |
+
+The landing globe pills are a genuine toggle, so the call there is guarded by
+`if (!isActive)`. The other three surfaces only ever *set* a category, so they
+fire unconditionally. The mobile "Catalogue" back button calls
+`setCategory(null)` and is not tracked — that is a clear, not a selection.
+
+### `Dataset Type Filter`
+
+The monitors / geostories / all switch changed.
+
+| Prop | Type |
+| --- | --- |
+| `dataset_type` | `'all' \| 'monitors' \| 'geostories'` |
+| `source` | [`EventSource`](#event-sources) |
+
+| File | Surface |
+| --- | --- |
+| `components/sidebar/select.tsx` | Explore sidebar select |
+| `containers/globe/mobile-toolbar.tsx` | Landing mobile toolbar |
+| `containers/explore/toolbar/mobile/nav-bar/index.tsx` | Explore mobile nav bar |
+
+`components/filters-by-dataset-type/desktop` is presentational and receives
+`handleDatasetTypeChange` as a prop, so the event lives in each of the three
+containers that own the setter — not in the shared component.
+
+### `Histogram Open`
+
+A histogram was opened from a map tooltip.
+
+| Prop | Type |
+| --- | --- |
+| `histogram_type` | `'point' \| 'region'` |
+| `layer_id` | `string` |
+| `source` | [`EventSource`](#event-sources) |
+
+The two histogram buttons are mutually exclusive and driven by
+`regionsLayerVisibilityAtom`: **"Show point histogram"** renders while the
+regions layer is off, **"Show region histogram"** while it is on. Rather than
+two event names, one event carries `histogram_type` so the two can be compared
+in a single breakdown.
+
+| File | Handler | `histogram_type` |
+| --- | --- | --- |
+| `components/map/tooltip/index.tsx` | `handleClick` | `point` |
+| `components/map/tooltip/index.tsx` | `handleHistogram` | `region` |
+| `components/map/tooltip/geostory-tooltip.tsx` | `handleClick` | `point` |
+| `components/map/tooltip/geostory-tooltip.tsx` | `handleHistogram` | `region` |
+
+In the geostory tooltip both handlers are bound twice — once for `leftData` and
+once for `rightData` in compare mode — but they always describe the same layer,
+`leftData.id`.
+
+### `Regions Layer Activate`
+
+The regions (NUTS) overlay was switched **on**. Switching it off is not tracked,
+matching `Layer Activate`.
+
+| Prop | Type |
+| --- | --- |
+| `source` | [`EventSource`](#event-sources) |
+
+Fired from `components/map/controls/basemaps/index.tsx`.
+
+### `Basemap Change`
+
+| Prop | Type |
+| --- | --- |
+| `basemap` | `'world_imagery' \| 'gray_scale'` |
+| `source` | [`EventSource`](#event-sources) |
+
+### `Map Labels Change`
+
+| Prop | Type |
+| --- | --- |
+| `labels` | `'dark' \| 'light' \| 'no-label'` |
+| `source` | [`EventSource`](#event-sources) |
+
+Both are fired from `components/map/controls/basemaps/index.tsx`, and both
+handlers already early-return when the value is unchanged, so re-selecting the
+active option sends nothing.
+
+The prop types are imported from
+`components/map/controls/basemaps/constants` as `import type`, so adding a
+basemap or label there widens the event type automatically with no runtime
+coupling.
+
+## Event sources
+
+`source` is a closed union rather than a free string, so a surface is always
+reported under the same name and breakdowns stay comparable over time.
+
+| Value | Where |
+| --- | --- |
+| `landing-globe` | Landing page globe, desktop |
+| `landing-globe-dialog` | Geostory dialog on the landing globe |
+| `landing-globe-mobile` | Landing page mobile toolbar |
+| `geostories-page` | Geostories listing page |
+| `monitors-page` | Monitors listing page |
+| `monitor-geostories` | Geostory sublist inside a monitor row |
+| `explore-sidebar` | Explore page sidebar, desktop |
+| `explore-mobile` | Explore page mobile nav bar |
+| `map-controls` | Map settings popover (basemap, labels, regions) |
+| `map-tooltip` | Monitor map tooltip |
+| `geostory-map-tooltip` | Geostory map tooltip |
+
+## Adding a new event
+
+1. Add the event name and its props to `AnalyticsEvents` in
+   `src/lib/analytics.ts`. Add a new `EventSource` member if the surface isn't
+   listed yet.
+2. Call it from a **client** component:
+   ```tsx
+   const track = useTrackEvent();
+   track('My Event', { props: { ... } });
+   ```
+3. If the call sits inside a `useCallback`, add `track` to the dependency array.
+   It is referentially stable (`usePlausible` memoises with `[]`), so this
+   doesn't cause re-renders.
+4. **Allow-list the prop keys in the Plausible dashboard.** See below.
+5. Update this document.
+
+### Dashboard configuration
+
+Custom properties are not automatically visible. Each key must be added under
+*Site settings → Custom properties* in the Plausible dashboard, otherwise the
+event count is recorded but every breakdown shows up empty. The keys currently
+in use:
+
+```
+geostory_id, monitor_id, layer_id, title, source,
+parent_type, category, dataset_type, histogram_type, basemap, labels
+```
+
+## Conventions and gotchas
+
+- **Activation only.** For anything that toggles — layers, categories, the
+  regions overlay — only the "on" transition is tracked. Off-transitions
+  roughly double event volume while adding no signal.
+- **Never track inside a state updater.** React may invoke an updater function
+  more than once, which would double-count. Compute the condition from current
+  state and fire before calling the setter:
+  ```tsx
+  if (!isActive) track('Category Filter', { props: { ... } });
+  setCategoriesFilter((prev) => { ... });
+  ```
+- **Hooks before early returns.** Several instrumented components early-return
+  (`if (!geostory) return null`). `useTrackEvent()` must be called above that
+  line to keep hook order stable across renders.
+- **Events are queued, not lost.** `PlausibleProvider` injects an init snippet
+  that stubs `window.plausible` with a queue, so a click that lands before the
+  script finishes loading is still delivered.
+- **Instrument the container, not the shared presentational component.** Where a
+  handler is passed down as a prop, the event belongs with whoever owns the
+  state, so the `source` can be set correctly per surface.
+
+## Relationship to `/usage-stats`
+
+Plausible is **not** the only counter in the app. `postWebTraffic` in
+`src/hooks/web-traffic.ts` POSTs to the backend `/usage-stats` endpoint, and
+those counts drive the "most visited" geostories and monitors shown in the UI.
+
+The two are independent and intentionally so — `/usage-stats` is a product
+feature whose numbers are rendered to users, while Plausible is for analysis.
+Some handlers call both. Don't replace one with the other.

--- a/src/components/datasets/card/index.tsx
+++ b/src/components/datasets/card/index.tsx
@@ -4,6 +4,7 @@ import { FC, useCallback, useEffect, useMemo } from 'react';
 
 import { useAtom } from 'jotai';
 
+import { useTrackEvent } from '@/lib/analytics';
 import { scrollToHistogram } from '@/lib/scroll-to-histogram';
 
 import { Geostory } from '@/types/geostories';
@@ -44,8 +45,17 @@ const DatasetCard: FC<DatasetCardProps> = ({
   const hasCompare = !!compareLayers?.[0]?.id;
 
   const [isHistogramActive] = useAtom(histogramVisibilityAtom);
+  const track = useTrackEvent();
 
   const handleToggleLayer = useCallback(() => {
+    track(isActive ? 'Layer Deactivate' : 'Layer Activate', {
+      props: {
+        layer_id: id,
+        title,
+        parent_type: isGeostory ? 'geostory' : 'monitor',
+      },
+    });
+
     if (!isActive) {
       void setLayers([
         {
@@ -81,6 +91,8 @@ const DatasetCard: FC<DatasetCardProps> = ({
     setLayers,
     comparisonLayer,
     compareLayers,
+    title,
+    track,
   ]);
 
   useEffect(() => {

--- a/src/components/datasets/card/index.tsx
+++ b/src/components/datasets/card/index.tsx
@@ -48,15 +48,15 @@ const DatasetCard: FC<DatasetCardProps> = ({
   const track = useTrackEvent();
 
   const handleToggleLayer = useCallback(() => {
-    track(isActive ? 'Layer Deactivate' : 'Layer Activate', {
-      props: {
-        layer_id: id,
-        title,
-        parent_type: isGeostory ? 'geostory' : 'monitor',
-      },
-    });
-
     if (!isActive) {
+      track('Layer Activate', {
+        props: {
+          layer_id: id,
+          title,
+          parent_type: isGeostory ? 'geostory' : 'monitor',
+        },
+      });
+
       void setLayers([
         {
           id,

--- a/src/components/geostories/item/index.tsx
+++ b/src/components/geostories/item/index.tsx
@@ -4,6 +4,8 @@ import Link from 'next/link';
 
 import { AnimatePresence, motion } from 'framer-motion';
 
+import { useTrackEvent } from '@/lib/analytics';
+
 import { Geostory } from '@/types/geostories';
 
 import { postWebTraffic } from '@/hooks/web-traffic';
@@ -11,11 +13,15 @@ import { postWebTraffic } from '@/hooks/web-traffic';
 import { TAG_STYLE } from '@/styles/constants';
 
 const GeostoryItem: FC<Geostory & { color: string }> = ({ id, color, title, geostory_bbox }) => {
+  const track = useTrackEvent();
+
   const handleClick = () => {
     postWebTraffic({
       geostory_id: id,
     });
-    console.info('WT5 -', 'geostories', id);
+    track('Geostory Open', {
+      props: { geostory_id: id, title, source: 'geostories-page' },
+    });
   };
   return (
     <Link

--- a/src/components/globe/geostory-dialog.tsx
+++ b/src/components/globe/geostory-dialog.tsx
@@ -7,6 +7,7 @@ import Link from 'next/link';
 
 import { LuArrowRight, LuX } from 'react-icons/lu';
 
+import { useTrackEvent } from '@/lib/analytics';
 import { cn } from '@/lib/classnames';
 
 import type { Geostory } from '@/types/geostories';
@@ -40,6 +41,7 @@ function getCategoryColor(theme: CategoryId | string): string {
 
 export default function GeostoryDialog({ geostory, open, onOpenChange }: GeostoryDialogProps) {
   const [activeTab, setActiveTab] = useState<Tab>('overview');
+  const track = useTrackEvent();
 
   if (!geostory) return null;
 
@@ -203,6 +205,15 @@ export default function GeostoryDialog({ geostory, open, onOpenChange }: Geostor
           href={`/explore/geostory/${geostory.id}`}
           className="absolute bottom-3 right-3 flex h-9 w-9 items-center justify-center rounded-full text-brand-500 transition-opacity hover:opacity-80"
           style={{ backgroundColor: color }}
+          onClick={() =>
+            track('Geostory Open', {
+              props: {
+                geostory_id: geostory.id,
+                title: geostory.title,
+                source: 'landing-globe-dialog',
+              },
+            })
+          }
         >
           <LuArrowRight className="h-4 w-4" />
         </Link>

--- a/src/components/map/controls/basemaps/index.tsx
+++ b/src/components/map/controls/basemaps/index.tsx
@@ -1,6 +1,7 @@
 import { PopoverTrigger } from '@radix-ui/react-popover';
 import { useAtom } from 'jotai';
 
+import { useTrackEvent } from '@/lib/analytics';
 import { cn } from '@/lib/classnames';
 
 import { histogramVisibilityAtom, regionsLayerVisibilityAtom } from '@/app/store';
@@ -21,20 +22,26 @@ const BasemapControl = ({ isMobile }: { isMobile?: boolean }) => {
   const [, setHistogramVisibility] = useAtom(histogramVisibilityAtom);
   // isActive is based on the url
   const [regionsLayerVisibility, setIsRegionsLayerActive] = useAtom(regionsLayerVisibilityAtom);
+  const track = useTrackEvent();
 
   const handleRegionsLayerVisibility = () => {
+    if (!regionsLayerVisibility) {
+      track('Regions Layer Activate', { props: { source: 'map-controls' } });
+    }
     setIsRegionsLayerActive((prev) => !prev);
     setHistogramVisibility(false);
   };
 
   const handleMapLabels = (value: LabelProps['id']) => {
     if (activeLabels !== value) {
+      track('Map Labels Change', { props: { labels: value, source: 'map-controls' } });
       setActiveLabels(value);
     }
   };
 
   const handleBasemap = (value: BasemapProps['id']) => {
     if (selectedBasemap !== value) {
+      track('Basemap Change', { props: { basemap: value, source: 'map-controls' } });
       setBasemap(value);
     }
   };

--- a/src/components/map/tooltip/geostory-tooltip.tsx
+++ b/src/components/map/tooltip/geostory-tooltip.tsx
@@ -7,6 +7,8 @@ import { useAtom, useSetAtom } from 'jotai';
 import { Coordinate } from 'ol/coordinate';
 import TileWMS from 'ol/source/TileWMS';
 
+import { useTrackEvent } from '@/lib/analytics';
+
 import {
   coordinateAtom,
   histogramVisibilityAtom,
@@ -40,7 +42,17 @@ const GeostoryTooltip: FC<TooltipProps> = ({
   const [isRegionsLayerActive] = useAtom(regionsLayerVisibilityAtom);
   const isHistogramVisibility = useSetAtom(histogramVisibilityAtom);
 
+  const track = useTrackEvent();
+
+  // "Show point histogram" — only rendered while the regions layer is off.
   const handleClick = () => {
+    track('Histogram Open', {
+      props: {
+        histogram_type: 'point',
+        layer_id: leftData.id,
+        source: 'geostory-map-tooltip',
+      },
+    });
     isHistogramVisibility(true);
   };
 
@@ -58,7 +70,15 @@ const GeostoryTooltip: FC<TooltipProps> = ({
     });
   }, []);
 
+  // "Show region histogram" — only rendered while the regions layer is on.
   const handleHistogram = useCallback(async () => {
+    track('Histogram Open', {
+      props: {
+        histogram_type: 'region',
+        layer_id: leftData.id,
+        source: 'geostory-map-tooltip',
+      },
+    });
     const { nutsDataParams } = await getHistogramData(
       wmsNutsSource,
       coordinate as Coordinate,
@@ -74,6 +94,7 @@ const GeostoryTooltip: FC<TooltipProps> = ({
     isHistogramVisibility,
     setNutsDataParams,
     wmsNutsSource,
+    track,
   ]);
 
   if (!position || !leftData?.value) return null;

--- a/src/components/map/tooltip/index.tsx
+++ b/src/components/map/tooltip/index.tsx
@@ -15,6 +15,7 @@ import { useAtom, useAtomValue } from 'jotai';
 import { toLonLat } from 'ol/proj';
 import { LuX } from 'react-icons/lu';
 
+import { useTrackEvent } from '@/lib/analytics';
 import { scrollToHistogram } from '@/lib/scroll-to-histogram';
 
 import {
@@ -48,6 +49,7 @@ const MapTooltip: FC<MapTooltipProps> = ({
   data,
 }) => {
   const [isHistogramActive, setHistogramVisibility] = useAtom(histogramVisibilityAtom);
+  const track = useTrackEvent();
   const nutsDataResponse = useAtomValue(nutsDataResponseAtom);
   const countryName = useCountryName(nutsDataResponse?.CNTR_CODE);
 
@@ -68,15 +70,25 @@ const MapTooltip: FC<MapTooltipProps> = ({
     [setHistogramVisibility]
   );
 
+  // Bound to the "Show region histogram" button, which only renders while the
+  // regions layer is on.
   const handleHistogram = useCallback(() => {
+    track('Histogram Open', {
+      props: { histogram_type: 'region', layer_id: data?.id, source: 'map-tooltip' },
+    });
     revealHistogram(data?.id);
-  }, [revealHistogram, data?.id]);
+  }, [revealHistogram, data?.id, track]);
 
   const [isRegionsLayerActive] = useAtom(regionsLayerVisibilityAtom);
 
+  // Bound to the "Show point histogram" button, which only renders while the
+  // regions layer is off.
   const handleClick = useCallback(() => {
+    track('Histogram Open', {
+      props: { histogram_type: 'point', layer_id: data?.id, source: 'map-tooltip' },
+    });
     revealHistogram(data?.id);
-  }, [revealHistogram, data?.id]);
+  }, [revealHistogram, data?.id, track]);
 
   // Clicking a new map location refreshes this tooltip with new coordinates.
   // If the histogram panel is already visible the user expects it to follow

--- a/src/components/monitors/table/item/geostory.tsx
+++ b/src/components/monitors/table/item/geostory.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { motion, AnimatePresence, useAnimationControls } from 'framer-motion';
 import { HiOutlineChevronUp } from 'react-icons/hi';
 
+import { useTrackEvent } from '@/lib/analytics';
 import { cn } from '@/lib/classnames';
 
 import { MonitorParsed } from '@/types/monitors';
@@ -25,11 +26,15 @@ export const GeostoriesLink = ({ geostories = [], color, colorOpacity }: Monitor
     }
   };
 
-  const handleClick = (id) => {
+  const track = useTrackEvent();
+
+  const handleClick = (id: string, title: string) => {
     postWebTraffic({
       geostory_id: id,
     });
-    console.info('WT3 -', 'geostories', id);
+    track('Geostory Open', {
+      props: { geostory_id: id, title, source: 'monitor-geostories' },
+    });
   };
 
   return (
@@ -84,7 +89,12 @@ export const GeostoriesLink = ({ geostories = [], color, colorOpacity }: Monitor
                   whileHover="hover"
                   className="w-fit"
                 >
-                  <a href={href} data-id={geostoryId} className="block" onClick={handleClick}>
+                  <a
+                    href={href}
+                    data-id={geostoryId}
+                    className="block"
+                    onClick={() => handleClick(geostoryId, title)}
+                  >
                     <div className="text-left">
                       <span>{title}</span>
                       <motion.div

--- a/src/components/monitors/table/item/monitor.tsx
+++ b/src/components/monitors/table/item/monitor.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 
 import { motion } from 'framer-motion';
 
+import { useTrackEvent } from '@/lib/analytics';
 import { cn } from '@/lib/classnames';
 
 import { MonitorParsed } from '@/types/monitors';
@@ -17,11 +18,15 @@ export const MonitorLink = ({
   title,
   isMobile,
 }: MonitorParsed & { isMobile?: boolean }) => {
+  const track = useTrackEvent();
+
   const handleClick = () => {
     postWebTraffic({
       monitor_id: id,
     });
-    console.info('WT4 -', 'monitors', id);
+    track('Monitor Open', {
+      props: { monitor_id: id, title, source: 'monitors-page' },
+    });
   };
 
   const { data: monitorsData } = useMonitors();

--- a/src/components/sidebar/card-geostory-content.tsx
+++ b/src/components/sidebar/card-geostory-content.tsx
@@ -4,6 +4,8 @@ import Link from 'next/link';
 
 import { ChevronRight } from 'lucide-react';
 
+import { useTrackEvent } from '@/lib/analytics';
+
 import type { GeostoryParsed } from '@/types/geostories';
 
 import { getGeostoryImageUrl } from '@/hooks/geostories';
@@ -14,6 +16,8 @@ import CardHeader from '@/components/sidebar/card-header';
 
 function DatasetCardGeostory({ theme, title, color, id, geostory_bbox }: GeostoryParsed) {
   // const validPublications = useMemo(() => getValidPublications(publications), [publications]);
+  const track = useTrackEvent();
+
   return (
     <div className="relative">
       <div
@@ -41,6 +45,11 @@ function DatasetCardGeostory({ theme, title, color, id, geostory_bbox }: Geostor
                 geostory_bbox ? `?bbox=${geostory_bbox.join(',')}` : ''
               }`}
               className="flex items-center justify-end"
+              onClick={() =>
+                track('Geostory Open', {
+                  props: { geostory_id: id, title, source: 'explore-sidebar' },
+                })
+              }
             >
               <span className="ml-2 inline-block w-0 overflow-hidden whitespace-nowrap font-inter text-xs text-white-500/50 opacity-0 transition-all duration-300 ease-in-out group-hover/monitor-card:w-full group-hover/monitor-card:opacity-100">
                 Go to geostory

--- a/src/components/sidebar/card-header.tsx
+++ b/src/components/sidebar/card-header.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link';
-import { useParams } from 'next/navigation';
 
+import { useTrackEvent } from '@/lib/analytics';
 import cn from '@/lib/classnames';
 
 import { postWebTraffic } from '@/hooks/web-traffic';
@@ -25,14 +25,20 @@ const CardHeader: React.FC<CardHeaderProps> = ({
   className,
   bbox,
 }) => {
-  const params = useParams();
-  const geostoryId = params.geostory_id;
+  const track = useTrackEvent();
 
   const handleClick = () => {
-    postWebTraffic({
-      geostory_id: geostoryId,
-    });
-    console.info('WT2 -', type, id);
+    postWebTraffic(type === 'monitor' ? { monitor_id: id } : { geostory_id: id });
+
+    if (type === 'monitor') {
+      track('Monitor Open', {
+        props: { monitor_id: id, title, source: 'explore-sidebar' },
+      });
+    } else {
+      track('Geostory Open', {
+        props: { geostory_id: id, title, source: 'explore-sidebar' },
+      });
+    }
   };
 
   return (

--- a/src/components/sidebar/card-monitor-content.tsx
+++ b/src/components/sidebar/card-monitor-content.tsx
@@ -2,6 +2,8 @@ import Link from 'next/link';
 
 import { ChevronRight } from 'lucide-react';
 
+import { useTrackEvent } from '@/lib/analytics';
+
 import { useMonitor } from '@/hooks/monitors';
 
 import Loading from '@/components/loading';
@@ -18,6 +20,7 @@ function DatasetCardMonitor({
 }) {
   const { data: monitorData, isLoading: isLoadingMonitor } = useMonitor({ monitor_id: id });
   const { theme, title, geostories, monitor_bbox } = monitorData || {};
+  const track = useTrackEvent();
 
   if (!monitorData) return null;
 
@@ -47,6 +50,15 @@ function DatasetCardMonitor({
                   }`}
                   data-testid={`geostory-link-${geostory.id}`}
                   className="font-bold underline decoration-gray-400 hover:decoration-white-500 hover:decoration-2"
+                  onClick={() =>
+                    track('Geostory Open', {
+                      props: {
+                        geostory_id: geostory.id,
+                        title: geostory.title,
+                        source: 'explore-sidebar',
+                      },
+                    })
+                  }
                 >
                   {geostory.title}
                 </Link>
@@ -56,6 +68,11 @@ function DatasetCardMonitor({
                       geostory.geostory_bbox ? `?bbox=${geostory.geostory_bbox.join(',')}` : ''
                     }`}
                     className="flex items-center"
+                    onClick={() =>
+                      track('Monitor Open', {
+                        props: { monitor_id: id, title, source: 'explore-sidebar' },
+                      })
+                    }
                   >
                     <span className="ml-2 inline-block w-0 overflow-hidden whitespace-nowrap font-inter text-xs text-white-500/50 opacity-0 transition-all duration-300 ease-in-out group-hover/monitor-card:w-full group-hover/monitor-card:opacity-100">
                       Go to monitor

--- a/src/components/sidebar/select.tsx
+++ b/src/components/sidebar/select.tsx
@@ -1,11 +1,29 @@
+import { useCallback } from 'react';
+
+import { useTrackEvent, type DatasetType } from '@/lib/analytics';
+
 import { useSyncDatasetType } from '@/hooks/sync-query';
 
 import FilterByDatasetType from '@/components/filters-by-dataset-type/desktop';
 
 function SidebarSelect() {
   const [currentDataset, setDatasetType] = useSyncDatasetType();
+  const track = useTrackEvent();
 
-  return <FilterByDatasetType active={currentDataset} handleDatasetTypeChange={setDatasetType} />;
+  const handleDatasetTypeChange = useCallback(
+    (type: DatasetType) => {
+      track('Dataset Type Filter', { props: { dataset_type: type, source: 'explore-sidebar' } });
+      setDatasetType(type);
+    },
+    [setDatasetType, track]
+  );
+
+  return (
+    <FilterByDatasetType
+      active={currentDataset}
+      handleDatasetTypeChange={handleDatasetTypeChange}
+    />
+  );
 }
 
 export default SidebarSelect;

--- a/src/components/theme-filter/map-sidebar-item.tsx
+++ b/src/components/theme-filter/map-sidebar-item.tsx
@@ -2,6 +2,8 @@
 
 import { FC, useState } from 'react';
 
+import { useTrackEvent } from '@/lib/analytics';
+
 import { ALL_CATEGORY, CategoryId, CATEGORIES_COLORS } from '@/constants/categories';
 
 import { useSyncCategories } from '@/hooks/sync-query';
@@ -26,6 +28,7 @@ export type SidebarItemProps = {
 const SidebarItem = ({ Icon, button: btn }: SidebarItemProps) => {
   const [categories, setCategory] = useSyncCategories();
   const [isHovered, setIsHovered] = useState(false);
+  const track = useTrackEvent();
 
   const isAll = btn.id === ALL_CATEGORY.id;
   const isActive = isAll
@@ -34,6 +37,8 @@ const SidebarItem = ({ Icon, button: btn }: SidebarItemProps) => {
   const categoryColor = CATEGORIES_COLORS[btn.id]?.base ?? CATEGORIES_COLORS['Unknown']?.base;
 
   const handleClick = () => {
+    track('Category Filter', { props: { category: btn.id, source: 'explore-sidebar' } });
+
     if (isAll) {
       setCategory('All');
       return;

--- a/src/containers/explore/toolbar/mobile/nav-bar/index.tsx
+++ b/src/containers/explore/toolbar/mobile/nav-bar/index.tsx
@@ -4,6 +4,7 @@ import { useCallback, useState } from 'react';
 
 import { ChevronDownIcon, ChevronLeftIcon } from 'lucide-react';
 
+import { useTrackEvent, type DatasetType } from '@/lib/analytics';
 import cn from '@/lib/classnames';
 
 import { ALL_CATEGORY, CATEGORIES } from '@/constants/categories';
@@ -26,12 +27,22 @@ const MobileExploreNavbar = () => {
   const [categories, setCategory] = useSyncCategories();
   const category = categories?.[0] ?? null;
   const { results, isLoading, isFetched, sortingCriteria, setSortingCriteria } = useDatasets();
+  const track = useTrackEvent();
 
   const handleClick = useCallback(
     (id: CategoryId | typeof ALL_CATEGORY.id) => {
+      track('Category Filter', { props: { category: id, source: 'explore-mobile' } });
       setCategory(id as CategoryId[] | 'All');
     },
-    [setCategory]
+    [setCategory, track]
+  );
+
+  const handleDatasetTypeChange = useCallback(
+    (type: DatasetType) => {
+      track('Dataset Type Filter', { props: { dataset_type: type, source: 'explore-mobile' } });
+      setDatasetType(type);
+    },
+    [setDatasetType, track]
   );
 
   const toggle = useCallback(() => setIsOpen((v) => !v), []);
@@ -79,7 +90,7 @@ const MobileExploreNavbar = () => {
               <section className="space-y-6 p-6">
                 <FilterByDatasetType
                   active={currentDataset}
-                  handleDatasetTypeChange={setDatasetType}
+                  handleDatasetTypeChange={handleDatasetTypeChange}
                   className="gap-10"
                 />
 

--- a/src/containers/globe/filters/item.tsx
+++ b/src/containers/globe/filters/item.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useMemo } from 'react';
 
+import { useTrackEvent } from '@/lib/analytics';
 import cn from '@/lib/classnames';
 
 import { CATEGORIES, CATEGORIES_COLORS } from '@/constants/categories';
@@ -16,6 +17,7 @@ type ItemProps = {
 
 const Filter = ({ id, label, Icon, className, theme }: ItemProps) => {
   const [categoriesFilter, setCategoriesFilter] = useSyncCategories();
+  const track = useTrackEvent();
 
   const categories = useMemo(() => CATEGORIES.map((c) => c.id), []);
   const isActive = useMemo(() => {
@@ -26,6 +28,12 @@ const Filter = ({ id, label, Icon, className, theme }: ItemProps) => {
   }, [categoriesFilter, id]);
 
   const handleCategory = useCallback(() => {
+    // Reported outside the updater below: React may invoke a state updater more
+    // than once, which would double-count the event.
+    if (!isActive) {
+      track('Category Filter', { props: { category: id, source: 'landing-globe' } });
+    }
+
     setCategoriesFilter((prev) => {
       if (prev === 'All') {
         const next = categories?.filter((catId) => catId !== id);
@@ -44,7 +52,7 @@ const Filter = ({ id, label, Icon, className, theme }: ItemProps) => {
 
       return next;
     });
-  }, [id, categories, setCategoriesFilter]);
+  }, [id, categories, setCategoriesFilter, isActive, track]);
 
   return (
     <button

--- a/src/containers/globe/geostories/geostories-list/item.tsx
+++ b/src/containers/globe/geostories/geostories-list/item.tsx
@@ -1,6 +1,8 @@
 import Image from 'next/image';
 import Link from 'next/link';
 
+import { useTrackEvent } from '@/lib/analytics';
+
 import { Geostory } from '@/types/geostories';
 
 import { CATEGORIES_COLORS } from '@/constants/categories';
@@ -9,12 +11,18 @@ import { getGeostoryImageUrl } from '@/hooks/geostories';
 
 const GeostoryItem = (props: Geostory) => {
   const { id, title: label, theme } = props;
+  const track = useTrackEvent();
 
   return (
     <Link
       href={`explore/geostory/${id}`}
       data-testid={`geostory-item-${id}`}
       className="group/item flex cursor-pointer items-start"
+      onClick={() =>
+        track('Geostory Open', {
+          props: { geostory_id: id, title: label, source: 'landing-globe' },
+        })
+      }
     >
       <div
         className="mr-2 h-[79px] w-px shrink-0 whitespace-normal transition-[width] duration-200 ease-out group-hover/item:w-1"

--- a/src/containers/globe/mobile-toolbar.tsx
+++ b/src/containers/globe/mobile-toolbar.tsx
@@ -4,6 +4,7 @@ import { useCallback, useState } from 'react';
 
 import { ChevronDownIcon, ChevronLeftIcon } from 'lucide-react';
 
+import { useTrackEvent, type DatasetType } from '@/lib/analytics';
 import cn from '@/lib/classnames';
 
 import { ALL_CATEGORY, CATEGORIES } from '@/constants/categories';
@@ -26,12 +27,24 @@ const MobileGlobeBar = () => {
   const [categories, setCategory] = useSyncCategories();
   const category = categories?.[0] ?? null;
   const { results, isLoading, isFetched, sortingCriteria, setSortingCriteria } = useDatasets();
+  const track = useTrackEvent();
 
   const handleClick = useCallback(
     (id: CategoryId | typeof ALL_CATEGORY.id) => {
+      track('Category Filter', { props: { category: id, source: 'landing-globe-mobile' } });
       setCategory(id as CategoryId[] | 'All');
     },
-    [setCategory]
+    [setCategory, track]
+  );
+
+  const handleDatasetTypeChange = useCallback(
+    (type: DatasetType) => {
+      track('Dataset Type Filter', {
+        props: { dataset_type: type, source: 'landing-globe-mobile' },
+      });
+      setDatasetType(type);
+    },
+    [setDatasetType, track]
   );
 
   const toggle = useCallback(() => setIsOpen((v) => !v), []);
@@ -76,7 +89,7 @@ const MobileGlobeBar = () => {
               <section className="space-y-6 p-6">
                 <FilterByDatasetType
                   active={currentDataset}
-                  handleDatasetTypeChange={setDatasetType}
+                  handleDatasetTypeChange={handleDatasetTypeChange}
                   className="gap-10"
                 />
 

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,5 +1,12 @@
 import { usePlausible } from 'next-plausible';
 
+import { ALL_CATEGORY, type CategoryId } from '@/constants/categories';
+
+import type { BasemapProps, LabelProps } from '@/components/map/controls/basemaps/constants';
+
+/** Mirrors the shape stored by `useSyncDatasetType`. */
+export type DatasetType = 'all' | 'monitors' | 'geostories';
+
 /**
  * Where in the UI the interaction happened. Kept as a closed union so the same
  * surface is always reported under the same name and the Plausible breakdown
@@ -8,10 +15,15 @@ import { usePlausible } from 'next-plausible';
 export type EventSource =
   | 'landing-globe'
   | 'landing-globe-dialog'
+  | 'landing-globe-mobile'
   | 'geostories-page'
   | 'monitors-page'
   | 'monitor-geostories'
-  | 'explore-sidebar';
+  | 'explore-sidebar'
+  | 'explore-mobile'
+  | 'map-controls'
+  | 'map-tooltip'
+  | 'geostory-map-tooltip';
 
 /**
  * Every custom event the app sends, with the custom properties it carries.
@@ -33,6 +45,46 @@ export type AnalyticsEvents = {
     layer_id: string;
     title: string;
     parent_type: 'monitor' | 'geostory';
+  };
+  /**
+   * A category was selected. Clearing a category is not reported, so the
+   * breakdown reads as interest per category rather than raw toggle volume.
+   */
+  'Category Filter': {
+    category: CategoryId | typeof ALL_CATEGORY.id;
+    source: EventSource;
+  };
+  /** The monitors / geostories / all switch changed. */
+  'Dataset Type Filter': {
+    dataset_type: DatasetType;
+    source: EventSource;
+  };
+  /**
+   * A histogram was opened from a map tooltip. `histogram_type` distinguishes
+   * the two buttons, which are mutually exclusive: the point one shows while
+   * the regions layer is off, the region one while it is on.
+   */
+  'Histogram Open': {
+    histogram_type: 'point' | 'region';
+    layer_id: string;
+    source: EventSource;
+  };
+  /**
+   * The regions (NUTS) overlay was switched on. Switching it off is not
+   * reported, matching the layer events.
+   */
+  'Regions Layer Activate': {
+    source: EventSource;
+  };
+  /** The basemap was changed. Only fires on an actual change. */
+  'Basemap Change': {
+    basemap: BasemapProps['id'];
+    source: EventSource;
+  };
+  /** The map label overlay was changed. Only fires on an actual change. */
+  'Map Labels Change': {
+    labels: LabelProps['id'];
+    source: EventSource;
   };
 };
 

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -34,11 +34,6 @@ export type AnalyticsEvents = {
     title: string;
     parent_type: 'monitor' | 'geostory';
   };
-  'Layer Deactivate': {
-    layer_id: string;
-    title: string;
-    parent_type: 'monitor' | 'geostory';
-  };
 };
 
 /**

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,51 @@
+import { usePlausible } from 'next-plausible';
+
+/**
+ * Where in the UI the interaction happened. Kept as a closed union so the same
+ * surface is always reported under the same name and the Plausible breakdown
+ * stays comparable over time.
+ */
+export type EventSource =
+  | 'landing-globe'
+  | 'landing-globe-dialog'
+  | 'geostories-page'
+  | 'monitors-page'
+  | 'monitor-geostories'
+  | 'explore-sidebar';
+
+/**
+ * Every custom event the app sends, with the custom properties it carries.
+ * Passing this to `usePlausible` makes both event names and props type-checked
+ * at the call site.
+ */
+export type AnalyticsEvents = {
+  'Geostory Open': {
+    geostory_id: string;
+    title: string;
+    source: EventSource;
+  };
+  'Monitor Open': {
+    monitor_id: string;
+    title: string;
+    source: EventSource;
+  };
+  'Layer Activate': {
+    layer_id: string;
+    title: string;
+    parent_type: 'monitor' | 'geostory';
+  };
+  'Layer Deactivate': {
+    layer_id: string;
+    title: string;
+    parent_type: 'monitor' | 'geostory';
+  };
+};
+
+/**
+ * Typed Plausible event sender.
+ *
+ * Only usable from client components. Calls made before the Plausible script
+ * finishes loading are queued by the init snippet that `PlausibleProvider`
+ * injects, so no event is lost on a fast click.
+ */
+export const useTrackEvent = () => usePlausible<AnalyticsEvents>();

--- a/src/utils/providers.tsx
+++ b/src/utils/providers.tsx
@@ -26,7 +26,7 @@ const Providers: ProvidersProps = ({ children }) => {
   return (
     <TooltipProvider>
       <PlausibleProvider
-        domain="https://app.earthmonitor.org/"
+        domain="app.earthmonitor.org"
         trackOutboundLinks
         trackFileDownloads
         selfHosted


### PR DESCRIPTION
## Summary

Analytics tracking was reported dead in production. It turned out the Plausible script **was** shipping correctly — the `data-domain` it sent could never match the registered site, so every event was dropped on ingest. This fixes that and adds the custom events the platform was missing.

Closes [OEMC-442](https://vizzuality.atlassian.net/browse/OEMC-442).

## Root cause

`src/utils/providers.tsx` set `domain="https://app.earthmonitor.org/"`. `next-plausible` passes that prop straight through to the script's `data-domain` attribute, and Plausible matches it against the domain registered in the dashboard, which is stored as a bare hostname. The protocol and trailing slash meant nothing was ever attributed.

```diff
- domain="https://app.earthmonitor.org/"
+ domain="app.earthmonitor.org"
```

Neither hypothesis on the ticket was right:

- **"Script not included after the redesign"** — it ships fine. The SSR HTML carries a `<link rel="preload">` and `next/script` injects the real tag after hydration, which is normal `afterInteractive` behaviour. The `enabled` gate also passes: it defaults to `NODE_ENV === 'production' && (!NEXT_PUBLIC_VERCEL_ENV || … === 'production')`, and this project deploys via Docker so the Vercel variable is unset.
- **"Nothing to track in the old environment"** — `git log -L` shows the bad value landed in the same commit that first added `PlausibleProvider`. Ingestion never worked, so this is not a redesign regression.

## Custom events

There were none — zero `usePlausible` calls and zero `plausible-event-*` classes. Only pageviews, outbound links and file downloads were being collected.

Added `src/lib/analytics.ts`, which passes an event map to `usePlausible` so **event names and props are type-checked at the call site**:

| Event | Props |
|---|---|
| `Geostory Open` | `geostory_id`, `title`, `source` |
| `Monitor Open` | `monitor_id`, `title`, `source` |
| `Layer Activate` | `layer_id`, `title`, `parent_type` |
| `Category Filter` | `category`, `source` |
| `Dataset Type Filter` | `dataset_type`, `source` |
| `Histogram Open` | `histogram_type`, `layer_id`, `source` |
| `Regions Layer Activate` | `source` |
| `Basemap Change` | `basemap`, `source` |
| `Map Labels Change` | `labels`, `source` |

25 call sites across 11 surfaces. `source` is a closed union, not a free string, so a surface always reports under the same name and breakdowns stay comparable.

## Design decisions

- **Activation only.** Layers, categories and the regions overlay report the "on" transition only. Off-transitions would roughly double event volume without adding signal.
- **One histogram event, not two.** The point and region buttons are mutually exclusive, driven by the regions-layer toggle, so they share `Histogram Open` with a `histogram_type` prop — comparable in a single breakdown.
- **Filters instrumented per container.** `FilterByDatasetType` is presentational and receives its handler as a prop, so the event lives with whichever container owns the setter — the only place that knows its own `source`. Same for the category filter across its four surfaces.
- **Never fired inside a state updater.** On the landing globe pills the event fires before `setCategoriesFilter`; React may invoke an updater more than once, which would double-count.

## Drive-by bug fixes

Two pre-existing bugs in the `/usage-stats` counter that feeds the "most visited" UI, both in handlers this PR already touches:

1. `monitors/table/item/geostory.tsx` declared `handleClick(id)` but passed it straight to `onClick`, so it POSTed the React synthetic event as the geostory id.
2. `sidebar/card-header.tsx` POSTed `useParams().geostory_id` — the geostory of the *current route*, not the card clicked — and always used the `geostory_id` key even for monitors.

⚠️ These counts have been wrong independently of Plausible. They will start counting correctly now, so existing `/usage-stats` data is not comparable with what follows.

Also removed the `WT2`–`WT5` `console.info` calls, which were shipping to the production console.

## Documentation

`docs/analytics.md` (linked from the README): provider setup and its two failure modes, every event with its call sites, the `source` union, an add-an-event checklist, the gotchas above, and why `/usage-stats` is deliberately separate from Plausible.

## Test plan

- [x] `yarn check-types` clean
- [x] `yarn lint` clean — one pre-existing error remains in build-generated, untracked `next-env.d.ts`
- [x] `yarn build` exit 0
- [x] Corrected `domain:"app.earthmonitor.org"` confirmed in `.next/static/chunks/`; old value gone
- [x] All nine event names confirmed present in the production bundle
- [ ] **Confirm the registered domain in the Plausible dashboard matches `app.earthmonitor.org`.** If the site is registered under a different string, the fix must match it exactly.
- [ ] **Allow-list the custom property keys** under *Site settings → Custom properties*. Until this is done the events count but every breakdown renders empty:
      `geostory_id, monitor_id, layer_id, title, source, parent_type, category, dataset_type, histogram_type, basemap, labels`
- [ ] After deploy, confirm a pageview and one custom event land in the dashboard
- [ ] No e2e coverage added for the events; the existing `data-testid`s make it straightforward if wanted

## Note for the reviewer

Nothing here can be validated end-to-end until the two dashboard steps above are done — both are configuration, not code. The build-level checks confirm the events are wired and shipping, but not that Plausible accepts them.
