### PR TITLE
fix: make histogram labels and scales resilient to degenerate data (OEMC-441)

### DIFF
--- a/src/components/line-chart/index.tsx
+++ b/src/components/line-chart/index.tsx
@@ -16,7 +16,41 @@ import { format } from 'd3-format';
 
 const numberFormat = format(',.2f');
 
+// Rotated tick labels need roughly this much horizontal room before they start
+// colliding with their neighbours.
+const PIXELS_PER_X_TICK = 72;
+const MAX_X_TICK_LABEL_LENGTH = 20;
+
 type LineChartDatum = { x: string | number | Date; y: number | null; unit?: string };
+
+const tickLabelFormat = format(',.4~f');
+
+// Keep at most `maxTicks` evenly spaced values. Ordinal (point) scales render one
+// tick per datum, which overlaps as soon as a series has more than a handful of
+// entries.
+function decimate<T>(values: T[], maxTicks: number): T[] {
+  if (values.length <= maxTicks) return values;
+
+  const step = Math.ceil(values.length / maxTicks);
+  return values.filter((_, i) => i % step === 0);
+}
+
+function formatXTickLabel(value: unknown, isDate: boolean): string {
+  if (isDate) {
+    return new Intl.DateTimeFormat('en-GB', { month: 'short', year: 'numeric' }).format(
+      new Date(value as string)
+    );
+  }
+
+  if (typeof value === 'number') return tickLabelFormat(value);
+
+  // A label longer than the axis can show would otherwise be clipped at the
+  // chart edge with no indication that it continues.
+  const label = String(value);
+  return label.length > MAX_X_TICK_LABEL_LENGTH
+    ? `${label.slice(0, MAX_X_TICK_LABEL_LENGTH - 1)}…`
+    : label;
+}
 
 function formatDate(value: unknown): string {
   const date = new Date(value as string);
@@ -83,136 +117,158 @@ export const LineChart = ({
     () => [...validData.map(accessors.yAccessor), ...validCompareData.map(accessors.yAccessor)],
     [validData, validCompareData, accessors.yAccessor]
   );
-  const yMin = useMemo(() => (allY.length ? Math.min(...allY) : 0), [allY]);
-  const yMax = useMemo(() => (allY.length ? Math.max(...allY) : 0), [allY]);
+  // A single-valued or perfectly flat series gives min === max, which collapses
+  // the linear scale to zero height and hides the line entirely. Pad around the
+  // value so it renders mid-chart.
+  const yDomain = useMemo(() => {
+    if (!allY.length) return [0, 1];
+
+    const min = Math.min(...allY);
+    const max = Math.max(...allY);
+    if (min !== max) return [min, max];
+
+    const padding = Math.abs(min) || 1;
+    return [min - padding, max + padding];
+  }, [allY]);
+
+  const xValues = useMemo(() => validData.map((d) => d.x), [validData]);
   const unit = validData[0]?.unit || '';
   return (
     <div ref={containerRef} className="relative h-72 w-full text-white-500">
       <ParentSize>
-        {({ width, height }) => (
-          <XYChart
-            theme={theme}
-            width={width}
-            height={height}
-            xScale={{ type: xScaleType }}
-            yScale={{ type: 'linear', domain: [yMin, yMax] }}
-            margin={{ top: 30, right: 20, bottom: 80, left: 60 }}
-          >
-            <Label
-              x={90}
-              y={30}
-              title={unit}
-              titleFontSize={12}
-              fontColor="#dfdfdf"
-              backgroundFill="transparent"
-            />
-            <AnimatedAxis
-              orientation="bottom"
-              tickLabelProps={() => ({
-                angle: -45,
-                textAnchor: 'end',
-                dx: '-0.5em',
-                dy: '0',
-                fontSize: 12,
-                fill: '#dfdfdf',
-              })}
-            />
-            <AnimatedAxis
-              orientation="left"
-              tickLabelProps={() => ({
-                dx: '-0.25em',
-                dy: '0.25em',
-                fontSize: 12,
-                fill: '#dfdfdf',
-                textAnchor: 'end',
-              })}
-            />
+        {({ width, height }) => {
+          const maxXTicks = Math.max(2, Math.floor(width / PIXELS_PER_X_TICK));
 
-            <AnimatedGrid columns={false} numTicks={5} stroke="#13273c" strokeWidth={0.5} />
+          return (
+            <XYChart
+              theme={theme}
+              width={width}
+              height={height}
+              xScale={{ type: xScaleType }}
+              yScale={{ type: 'linear', domain: yDomain }}
+              margin={{ top: 30, right: 20, bottom: 80, left: 60 }}
+            >
+              <Label
+                x={90}
+                y={30}
+                title={unit}
+                titleFontSize={12}
+                fontColor="#dfdfdf"
+                backgroundFill="transparent"
+              />
+              <AnimatedAxis
+                orientation="bottom"
+                numTicks={maxXTicks}
+                // Ordinal scales ignore numTicks and draw every domain entry, so
+                // thin the values out explicitly.
+                tickValues={xScaleType === 'point' ? decimate(xValues, maxXTicks) : undefined}
+                tickFormat={(value) => formatXTickLabel(value, isDate)}
+                tickLabelProps={() => ({
+                  angle: -45,
+                  textAnchor: 'end',
+                  dx: '-0.5em',
+                  dy: '0',
+                  fontSize: 12,
+                  fill: '#dfdfdf',
+                })}
+              />
+              <AnimatedAxis
+                orientation="left"
+                tickLabelProps={() => ({
+                  dx: '-0.25em',
+                  dy: '0.25em',
+                  fontSize: 12,
+                  fill: '#dfdfdf',
+                  textAnchor: 'end',
+                })}
+              />
 
-            <AnimatedLineSeries
-              dataKey={data?.title}
-              data={validData}
-              xAccessor={accessors.xAccessor}
-              yAccessor={accessors.yAccessor}
-              colorAccessor={() => color}
-            />
-            {dataCompare && validCompareData.length > 0 && (
+              <AnimatedGrid columns={false} numTicks={5} stroke="#13273c" strokeWidth={0.5} />
+
               <AnimatedLineSeries
-                dataKey={dataCompare.title}
-                data={validCompareData}
+                dataKey={data?.title}
+                data={validData}
                 xAccessor={accessors.xAccessor}
                 yAccessor={accessors.yAccessor}
-                colorAccessor={() => compareColor || '#ffffe6'}
+                colorAccessor={() => color}
               />
-            )}
+              {dataCompare && validCompareData.length > 0 && (
+                <AnimatedLineSeries
+                  dataKey={dataCompare.title}
+                  data={validCompareData}
+                  xAccessor={accessors.xAccessor}
+                  yAccessor={accessors.yAccessor}
+                  colorAccessor={() => compareColor || '#ffffe6'}
+                />
+              )}
 
-            <Tooltip
-              showVerticalCrosshair
-              snapTooltipToDatumX
-              snapTooltipToDatumY
-              showSeriesGlyphs
-              detectBounds
-              renderTooltip={({ tooltipData, tooltipTop = 0, tooltipLeft = 0 }) => {
-                const nearest = tooltipData?.nearestDatum;
-                if (!nearest) return null;
-                const d = nearest.datum as LineChartDatum;
+              <Tooltip
+                showVerticalCrosshair
+                snapTooltipToDatumX
+                snapTooltipToDatumY
+                showSeriesGlyphs
+                detectBounds
+                renderTooltip={({ tooltipData, tooltipTop = 0, tooltipLeft = 0 }) => {
+                  const nearest = tooltipData?.nearestDatum;
+                  if (!nearest) return null;
+                  const d = nearest.datum as LineChartDatum;
 
-                const info = tooltipData.datumByKey[data?.title];
-                const compareInfo = tooltipData.datumByKey[dataCompare?.title];
+                  const info = tooltipData.datumByKey[data?.title];
+                  const compareInfo = tooltipData.datumByKey[dataCompare?.title];
 
-                return (
-                  <>
-                    {tooltipData?.nearestDatum && (
-                      <Line
-                        from={{ x: tooltipLeft, y: 0 }}
-                        to={{ x: tooltipLeft, y: height }}
-                        stroke="red"
-                        strokeWidth={1}
-                        pointerEvents="none"
-                      />
-                    )}
-                    <TooltipInPortal
-                      top={tooltipTop}
-                      left={tooltipLeft}
-                      style={{
-                        position: 'absolute',
-                        background: '#13273c',
-                        padding: '0.5rem',
-                        boxShadow: '0 0 4px rgba(0,0,0,0.3)',
-                        zIndex: 9999,
-                        pointerEvents: 'none',
-                        color: '#dfdfdf',
-                        fontSize: '0.875rem',
-                      }}
-                    >
-                      <div>
-                        <span>{formatDate(accessors.xAccessor(d))}</span>
-                        <span>{unit && ` (${unit})`}</span>
-                      </div>
-                      {!dataCompare && (
-                        <div>
-                          {numberFormat(accessors.yAccessor(d))} {unit}
-                        </div>
+                  return (
+                    <>
+                      {tooltipData?.nearestDatum && (
+                        <Line
+                          from={{ x: tooltipLeft, y: 0 }}
+                          to={{ x: tooltipLeft, y: height }}
+                          stroke="red"
+                          strokeWidth={1}
+                          pointerEvents="none"
+                        />
                       )}
-                      {dataCompare && (
+                      <TooltipInPortal
+                        top={tooltipTop}
+                        left={tooltipLeft}
+                        style={{
+                          position: 'absolute',
+                          background: '#13273c',
+                          padding: '0.5rem',
+                          boxShadow: '0 0 4px rgba(0,0,0,0.3)',
+                          zIndex: 9999,
+                          pointerEvents: 'none',
+                          color: '#dfdfdf',
+                          fontSize: '0.875rem',
+                        }}
+                      >
                         <div>
-                          <div>
-                            {info.key} - {numberFormat((info.datum as { y: number }).y)}
-                          </div>
-                          <div>
-                            {compareInfo.key} -{' '}
-                            {numberFormat((compareInfo.datum as { y: number }).y)}
-                          </div>
+                          <span>{formatDate(accessors.xAccessor(d))}</span>
+                          <span>{unit && ` (${unit})`}</span>
                         </div>
-                      )}
-                    </TooltipInPortal>
-                  </>
-                );
-              }}
-            />
-          </XYChart>
-        )}
+                        {!dataCompare && (
+                          <div>
+                            {numberFormat(accessors.yAccessor(d))} {unit}
+                          </div>
+                        )}
+                        {dataCompare && (
+                          <div>
+                            <div>
+                              {info.key} - {numberFormat((info.datum as { y: number }).y)}
+                            </div>
+                            <div>
+                              {compareInfo.key} -{' '}
+                              {numberFormat((compareInfo.datum as { y: number }).y)}
+                            </div>
+                          </div>
+                        )}
+                      </TooltipInPortal>
+                    </>
+                  );
+                }}
+              />
+            </XYChart>
+          );
+        }}
       </ParentSize>
     </div>
   );

--- a/src/components/line-chart/index.tsx
+++ b/src/components/line-chart/index.tsx
@@ -1,6 +1,5 @@
 import { useMemo } from 'react';
 
-import { Label } from '@visx/annotation';
 import { ParentSize } from '@visx/responsive';
 import { Line } from '@visx/shape';
 import { useTooltipInPortal } from '@visx/tooltip';
@@ -135,6 +134,17 @@ export const LineChart = ({
   const unit = validData[0]?.unit || '';
   return (
     <div ref={containerRef} className="relative h-72 w-full text-white-500">
+      {/* The unit sits in the chart's reserved top margin as HTML rather than an SVG
+          annotation: an annotation is positioned from measured text width, so a long
+          unit gets pushed past the left edge of the SVG and clipped mid-glyph. */}
+      {unit && (
+        <span
+          className="pointer-events-none absolute left-0 top-0 block max-w-full truncate text-xs text-[#dfdfdf]"
+          title={unit}
+        >
+          {unit}
+        </span>
+      )}
       <ParentSize>
         {({ width, height }) => {
           const maxXTicks = Math.max(2, Math.floor(width / PIXELS_PER_X_TICK));
@@ -148,14 +158,6 @@ export const LineChart = ({
               yScale={{ type: 'linear', domain: yDomain }}
               margin={{ top: 30, right: 20, bottom: 80, left: 60 }}
             >
-              <Label
-                x={90}
-                y={30}
-                title={unit}
-                titleFontSize={12}
-                fontColor="#dfdfdf"
-                backgroundFill="transparent"
-              />
               <AnimatedAxis
                 orientation="bottom"
                 numTicks={maxXTicks}

--- a/src/components/map/stats/point-histogram.tsx
+++ b/src/components/map/stats/point-histogram.tsx
@@ -8,6 +8,7 @@ import { FiDownload } from 'react-icons/fi';
 
 import { cn } from '@/lib/classnames';
 import { scrollToHistogram } from '@/lib/scroll-to-histogram';
+import { transformPointData } from '@/lib/utils';
 
 import { histogramVisibilityAtom, lonLatAtom } from '@/app/store';
 
@@ -60,33 +61,28 @@ const PointHistogram: FC<GeostoryTooltipInfo> = ({ title, color, id }: GeostoryT
     enabled: !!lonLat && !!regex,
   });
 
-  const histogramPointData = useMemo(() => {
-    return {
-      data: (Array.isArray(histogramData) ? histogramData : [])
-        .filter((d) => Number.isFinite(d?.value))
-        .map((d) => ({
-          x: d.label,
-          y: d.value,
-          unit: d.unit ?? '',
-        })),
-    };
-  }, [histogramData]);
+  const histogramPointData = useMemo(
+    () => ({ data: transformPointData(histogramData) }),
+    [histogramData]
+  );
 
+  // Export the normalised rows rather than the raw response, so the CSV carries
+  // the same label the chart plots.
   const handleClick = useCallback(() => {
-    if (histogramData) {
-      const data = Array.isArray(histogramData)
-        ? histogramData
-        : histogramPointData?.data?.map((d) => ({
-            layer_id: id,
-            label: d.x,
-            value: d.y,
-            unit: d.unit || '',
-          }));
-      downloadCSV(data, `data-${title}.csv`);
-    } else {
+    if (!histogramPointData.data.length) {
       console.error('No data available for download.');
+      return;
     }
-  }, [histogramData, histogramPointData, id, title]);
+
+    const data = histogramPointData.data.map((d) => ({
+      layer_id: id,
+      label: d.x,
+      value: d.y,
+      unit: d.unit,
+    }));
+
+    downloadCSV(data, `data-${title}.csv`);
+  }, [histogramPointData, id, title]);
 
   const handleCloseAnalysis = () => setHistogramVisibility(false);
 

--- a/src/components/map/types.d.ts
+++ b/src/components/map/types.d.ts
@@ -112,3 +112,10 @@ export type NutsDataset = {
 export type NuqsData = {
   dataset?: NutsDataset[];
 };
+
+export type PointDataset = {
+  label: string;
+  layer_id: string;
+  value: number | null;
+  unit?: string;
+};

--- a/src/hooks/map.ts
+++ b/src/hooks/map.ts
@@ -4,19 +4,14 @@ import { getCenter } from 'ol/extent';
 import { fromLonLat, toLonLat } from 'ol/proj';
 import View from 'ol/View';
 
+import { PointDataset } from '@/components/map/types';
+
 import API from 'services/api';
 
 type UseParams = {
   lon: number;
   lat: number;
   layer_id: string;
-};
-
-type RegionData = {
-  label: string;
-  layer_id: string;
-  value: number;
-  unit?: string;
 };
 
 const DEFAULT_QUERY_OPTIONS = {
@@ -29,7 +24,7 @@ const DEFAULT_QUERY_OPTIONS = {
 
 export function usePointData(
   params: UseParams,
-  queryOptions?: UseQueryOptions<RegionData[], AxiosError, RegionData[]>
+  queryOptions?: UseQueryOptions<PointDataset[], AxiosError, PointDataset[]>
 ) {
   const fetchRegionData = ({ signal }: { signal?: AbortSignal }) =>
     API.request({
@@ -39,7 +34,7 @@ export function usePointData(
       signal,
       ...queryOptions,
     })
-      .then((response: AxiosResponse<RegionData[] | string>) => {
+      .then((response: AxiosResponse<PointDataset[] | string>) => {
         // example - Soil moisture index 12,5km resolution HSAF ASCAT h121 over Europe ( layer_id: l25)
         // we could find it in geostory "Drought at high resolution in Europe" (geostory_id: g5)
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 import { Coordinate } from 'ol/coordinate';
 import { TileWMS } from 'ol/source';
 
-import { FeatureInfoResponse, NuqsData } from '../components/map/types';
+import { FeatureInfoResponse, NuqsData, PointDataset } from '../components/map/types';
 
 export const getHistogramData = async (
   wmsNutsSource: TileWMS,
@@ -44,27 +44,48 @@ const isValidDate = (dateStr: string) => {
   return date instanceof Date && !isNaN(date.getTime());
 };
 
+// Labels do not always arrive as a plain date: they can be a range
+// ("20140101-20140228"), in which case the start of the range is used. Anything
+// the chart cannot parse as a date falls back to an ordinal x scale, so both
+// histogram flavours normalise labels the same way.
+export const normalizeHistogramLabel = (label: string) => {
+  if (typeof label !== 'string' || isValidDate(label)) return label;
+
+  const [rangeStart] = label.split('-');
+  return isValidDate(rangeStart) ? rangeStart : label;
+};
+
 export const transformNuqsData = (data: NuqsData) => {
   return (
     data?.dataset?.reduce((acc, { label, avg, max, min }) => {
       if (avg === null || !Number.isFinite(avg)) return acc;
-      let date = label;
-      if (!isValidDate(label)) {
-        const range = label.split('-');
-        if (isValidDate(range[0])) {
-          date = range[0];
-        }
-      }
 
       return [
         ...acc,
         {
-          x: date,
+          x: normalizeHistogramLabel(label),
           y: avg,
           max: Number.isFinite(max) ? max : null,
           min: Number.isFinite(min) ? min : null,
         },
       ];
     }, []) || []
+  );
+};
+
+export const transformPointData = (data: PointDataset[] | undefined) => {
+  return (Array.isArray(data) ? data : []).reduce<{ x: string; y: number; unit: string }[]>(
+    (acc, { label, value, unit }) => {
+      if (value === null || !Number.isFinite(value)) return acc;
+
+      acc.push({
+        x: normalizeHistogramLabel(label),
+        y: value,
+        unit: unit ?? '',
+      });
+
+      return acc;
+    },
+    []
   );
 };


### PR DESCRIPTION
## Summary

Frontend half of OEMC-441. The reported truncated label and "only one value" both originate in `/point-query`, which returns the whole date axis as every row's label — that still needs a backend fix. These changes make the chart readable and consistent regardless of what the API returns.

## Changes

- **Y scale**: pad the domain when min equals max, so a single-valued or perfectly flat series no longer collapses the scale to zero height and hides the line.
- **X axis ticks**: thin ticks to what fits the chart width, and clamp over-long tick labels with an ellipsis instead of letting them clip at the chart edge. Ordinal (`point`) scales ignore `numTicks`, so their tick values are decimated explicitly.
- **Label normalisation**: share one normalisation step between the point and region transforms; the point path previously used the raw label as the x value.
- **CSV export**: export the normalised rows in the point CSV, so the file carries the same label the chart plots.
- **Unit label**: replace the `@visx/annotation` `Label` with an absolutely positioned HTML span in the chart's reserved top margin. The annotation was positioned from measured text width, so a long unit was pushed past the left edge of the SVG and clipped mid-glyph. The span truncates at the container width and exposes the full value via `title`.

## Test plan

- [ ] `yarn check-types` passes (verified locally)
- [ ] Point query on a layer with a long unit string — unit is visible, truncated with an ellipsis rather than clipped
- [ ] Point query returning a single value / flat series — line renders mid-chart instead of disappearing
- [ ] Point query with many entries — x-axis labels are thinned and do not overlap
- [ ] Region query histogram still renders unchanged
- [ ] CSV download for a point query contains the same labels shown on the chart
- [ ] Narrow viewport / resized panel — tick density adapts, no horizontal clipping

Note: `yarn lint` reports one pre-existing prettier error in the generated `next-env.d.ts`, untouched by this branch.