### PR TITLE
fix: keep the map credits legible and out of the way

### DIFF
--- a/src/components/map/attributions/index.tsx
+++ b/src/components/map/attributions/index.tsx
@@ -7,6 +7,8 @@ import Image from 'next/image';
 import { cn } from '@/lib/classnames';
 import { tablet } from '@/lib/media-queries';
 
+import { useSelectedBasemap } from '@/hooks/basemap';
+
 import SocialMedia from '@/components/footer/social-media';
 import {
   Dialog,
@@ -28,10 +30,19 @@ export const Controls: FC<ControlsPropsWithChildren> = ({
   className = 'absolute bottom-3 space-x-4',
 }: ControlsPropsWithChildren) => {
   const isTablet = useMediaQuery(tablet);
+  // The links are cream, which needs something dark behind them. A translucent
+  // white veil is enough over imagery but disappears over the near-white gray
+  // basemap, so the veil flips with the basemap. `defaultLabels: 'light'` is the
+  // basemaps' own way of saying "I am a light map and need dark text".
+  const basemap = useSelectedBasemap();
+  const isLightBasemap = basemap.defaultLabels === 'light';
+
   return (
     <div
       className={cn({
-        'bg-white-500/15 flex w-fit items-center rounded px-2 py-1 backdrop-blur-sm': true,
+        'flex w-fit items-center rounded px-2 py-1 backdrop-blur-sm': true,
+        'bg-black-500/70': isLightBasemap,
+        'bg-white-500/15': !isLightBasemap,
         [className]: !!className,
       })}
     >

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -171,16 +171,28 @@
  */
 .ol-attribution {
   position: absolute !important;
-  right: 12px !important;
-  bottom: 34px !important;
   left: auto !important;
   top: auto !important;
+  /* Above the 60px mobile toolbar, which is fixed to the bottom of the viewport. */
+  right: 12px !important;
+  bottom: 68px !important;
   max-width: min(70ch, calc(100% - 24px)) !important;
   padding: 2px 6px !important;
   border-radius: 4px;
   background: hsl(184 5% 19% / 0.55) !important;
   backdrop-filter: blur(4px);
   z-index: 40;
+}
+
+/* From `md` the legend occupies the bottom-right corner, so the credits sit
+   alongside it rather than underneath. `max-w-md` is 28rem, plus a gap. */
+@media (min-width: 768px) {
+  .ol-attribution {
+    right: 29rem !important;
+    /* Clear of the footer links, which sit on the `bottom-3` row themselves. */
+    bottom: 44px !important;
+    max-width: min(50ch, calc(100% - 30rem)) !important;
+  }
 }
 
 .ol-attribution ul {


### PR DESCRIPTION
## What

Follow-up to #225. That PR added the tile credits OpenLayers had never been rendering, but it was merged one commit before the placement fixes landed, so `develop` currently shows the credits in the wrong place and with the footer links unreadable on one basemap.

Three overlaps, all from map chrome that assumed a dark basemap in the bottom-right corner:

- **Footer links invisible over the gray basemap.** The links are cream on a translucent *white* veil — fine over imagery, gone over the near-white vector basemap. The veil now flips to dark, keyed off the basemap's own `defaultLabels` value, which is already its way of saying "I am a light map and need dark text". No new flag.
- **Credits printed on top of the footer links.** Both sat on the `bottom-3` row. The credits now sit beside the legend instead of underneath it, and clear that row.
- **Credits hidden on mobile.** The bottom toolbar is `fixed` and 60px tall, so it covered them completely. They now sit above it.

Cherry-picked from `feat/open-source-basemaps` (`7a32798`), unchanged, onto current `develop`.

## Test plan

- [x] `yarn check-types` clean
- [x] `yarn lint` clean
- [x] `e2e/basemap.spec.ts` — 10 passing against current develop
- [x] Measured placement at 1440x900: credits span x 471–976, legend starts x 992 — adjacent, clear of the footer links row
- [x] Measured at 390x844: credits bottom edge 68px up, above the 60px toolbar
- [x] Visually checked both basemap tones — footer links legible over the gray basemap and over imagery
- [ ] Reviewer: check placement at an intermediate width (verified at 1440 and 390)

**Local test note:** run with `--workers=1`; parallel workers against one dev server make `page.goto` time out across the suite. Also check nothing else is holding port 3000 — `reuseExistingServer` will happily test another project's app.

## Known limit

The desktop offset is hardcoded to `right: 29rem`, matching the legend's `max-w-md`. Two consequences: with no layer active the legend is not rendered, so the credits sit in that spot with nothing beside them (reads fine, just not obviously deliberate), and if the legend's width ever changes this needs changing with it.
