### PR TITLE
fix: make map settings labels clickable and drop the credits to the bottom row

### DIFF
--- a/e2e/basemap.spec.ts
+++ b/e2e/basemap.spec.ts
@@ -69,6 +69,40 @@ test.describe('labels follow the basemap', () => {
   });
 });
 
+test.describe('map settings', () => {
+  const openSettings = async (page: import('@playwright/test').Page) => {
+    await page.goto('/explore', { waitUntil: 'load' });
+    await page.getByRole('button', { name: 'Map settings' }).first().click();
+  };
+
+  // Each switch is driven from its label too, so the hit area is the whole row
+  // and not just the 27px control.
+  for (const [testId, label] of [
+    ['regions-layer-button', 'Regions layer'],
+    ['boundaries-layer-button', 'Country boundaries'],
+  ]) {
+    test(`the "${label}" label drives its switch`, async ({ page }) => {
+      await openSettings(page);
+
+      const row = page.getByTestId(testId);
+      const toggle = row.getByRole('switch');
+      const before = await toggle.getAttribute('aria-checked');
+
+      await row.getByText(label).click();
+
+      await expect(toggle).not.toHaveAttribute('aria-checked', before);
+    });
+  }
+
+  test('a basemap label selects that basemap', async ({ page }) => {
+    await openSettings(page);
+
+    await page.getByTestId('gray_scale-button').getByText('Gray scale').click();
+
+    await expect(page).toHaveURL(/basemap=%22gray_scale%22/);
+  });
+});
+
 test.describe('vector basemap', () => {
   test('the bundled style draws no labels of its own', async ({ request }) => {
     const response = await request.get('/basemaps/oemc.json');

--- a/src/components/map/controls/basemaps/index.tsx
+++ b/src/components/map/controls/basemaps/index.tsx
@@ -122,11 +122,14 @@ const BasemapControl = ({ isMobile }: { isMobile?: boolean }) => {
             data-testid="regions-layer-button"
           >
             <Switch
+              id="regions-layer"
               onCheckedChange={handleRegionsLayerVisibility}
               checked={regionsLayerVisibility}
               className="h-4 w-6 shrink-0"
             />
-            <Label htmlFor="regions-layer">Regions layer</Label>
+            <Label htmlFor="regions-layer" className="cursor-pointer">
+              Regions layer
+            </Label>
           </div>
 
           <div
@@ -135,11 +138,14 @@ const BasemapControl = ({ isMobile }: { isMobile?: boolean }) => {
             data-testid="boundaries-layer-button"
           >
             <Switch
+              id="boundaries-layer"
               onCheckedChange={handleBoundaries}
               checked={areBoundariesActive}
               className="h-4 w-6 shrink-0"
             />
-            <Label htmlFor="boundaries-layer">Country boundaries</Label>
+            <Label htmlFor="boundaries-layer" className="cursor-pointer">
+              Country boundaries
+            </Label>
           </div>
 
           <div className="flex flex-col justify-start space-y-4 py-6">
@@ -156,7 +162,9 @@ const BasemapControl = ({ isMobile }: { isMobile?: boolean }) => {
                   className="h-4 w-6 shrink-0"
                   onCheckedChange={() => handleBasemap(basemap.id)}
                 />
-                <Label htmlFor={basemap.id}>{basemap.label}</Label>
+                <Label htmlFor={basemap.id} className="cursor-pointer">
+                  {basemap.label}
+                </Label>
               </div>
             ))}
           </div>
@@ -175,7 +183,9 @@ const BasemapControl = ({ isMobile }: { isMobile?: boolean }) => {
                   className="h-4 w-6 shrink-0"
                   onCheckedChange={() => handleMapLabels(value.id)}
                 />
-                <Label htmlFor={value.id}>{value.label}</Label>
+                <Label htmlFor={value.id} className="cursor-pointer">
+                  {value.label}
+                </Label>
               </div>
             ))}
           </div>

--- a/src/components/map/index.tsx
+++ b/src/components/map/index.tsx
@@ -613,9 +613,10 @@ const Map: FC<CustomMapProps> = ({ initialViewState = DEFAULT_VIEWPORT }) => {
         />
 
         {isLayerActive && <Legend />}
-        {/* From 1440 the tile credits take the bottom row (see `.ol-attribution`
-            in globals.css), so the links move up to sit above them. */}
-        <Attributions className="absolute bottom-0 z-40 sm:left-auto sm:right-3 lg:bottom-3 lg:left-[620px] min-[1440px]:bottom-[76px]" />
+        {/* The tile credits take the bottom row (see `.ol-attribution` in
+            globals.css), so from `lg` — where the links would sit on that row
+            too — the links stack above them. */}
+        <Attributions className="absolute bottom-0 z-40 sm:left-auto sm:right-3 lg:bottom-[76px] lg:left-[620px]" />
       </RMap>
 
       <MapTooltip

--- a/src/components/map/index.tsx
+++ b/src/components/map/index.tsx
@@ -614,9 +614,10 @@ const Map: FC<CustomMapProps> = ({ initialViewState = DEFAULT_VIEWPORT }) => {
 
         {isLayerActive && <Legend />}
         {/* The tile credits take the bottom row (see `.ol-attribution` in
-            globals.css), so from `lg` — where the links would sit on that row
-            too — the links stack above them. */}
-        <Attributions className="absolute bottom-0 z-40 sm:left-auto sm:right-3 lg:bottom-[76px] lg:left-[620px]" />
+            globals.css). From `lg` the links would share that row, so they stack
+            above the credits; from 1900 there is room for both side by side and
+            the links return to the row itself. */}
+        <Attributions className="absolute bottom-0 z-40 sm:left-auto sm:right-3 lg:bottom-[76px] lg:left-[620px] min-[1900px]:bottom-3" />
       </RMap>
 
       <MapTooltip

--- a/src/components/map/index.tsx
+++ b/src/components/map/index.tsx
@@ -613,7 +613,9 @@ const Map: FC<CustomMapProps> = ({ initialViewState = DEFAULT_VIEWPORT }) => {
         />
 
         {isLayerActive && <Legend />}
-        <Attributions className="absolute bottom-0 z-40 sm:left-auto sm:right-3 lg:bottom-3 lg:left-[620px]" />
+        {/* From 1440 the tile credits take the bottom row (see `.ol-attribution`
+            in globals.css), so the links move up to sit above them. */}
+        <Attributions className="absolute bottom-0 z-40 sm:left-auto sm:right-3 lg:bottom-3 lg:left-[620px] min-[1440px]:bottom-[76px]" />
       </RMap>
 
       <MapTooltip

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -188,10 +188,23 @@
    alongside it rather than underneath. `max-w-md` is 28rem, plus a gap. */
 @media (min-width: 768px) {
   .ol-attribution {
+    /* Bounded on both sides: right of the sidebar, left of the legend
+       (`max-w-md` plus a gap), so the credits never slide under either. */
+    left: 460px !important;
     right: 29rem !important;
-    /* Clear of the footer links, which sit on the `bottom-3` row themselves. */
-    bottom: 44px !important;
-    max-width: min(50ch, calc(100% - 30rem)) !important;
+    bottom: 40px !important;
+    max-width: none !important;
+  }
+}
+
+/* From 1440 the bottom row is wide enough for the credits to sit on it, with the
+   footer links stacked above (`min-[1440px]:bottom-[60px]` on the links). Below
+   that the row cannot hold both, so the credits stay above the links instead. */
+@media (min-width: 1440px) {
+  .ol-attribution {
+    /* Clear of the back button in the bottom-left corner of the map. */
+    left: 500px !important;
+    bottom: 12px !important;
   }
 }
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -188,23 +188,11 @@
    alongside it rather than underneath. `max-w-md` is 28rem, plus a gap. */
 @media (min-width: 768px) {
   .ol-attribution {
-    /* Bounded on both sides: right of the sidebar, left of the legend
-       (`max-w-md` plus a gap), so the credits never slide under either. */
-    left: 460px !important;
     right: 29rem !important;
-    bottom: 40px !important;
-    max-width: none !important;
-  }
-}
-
-/* From 1440 the bottom row is wide enough for the credits to sit on it, with the
-   footer links stacked above (`min-[1440px]:bottom-[60px]` on the links). Below
-   that the row cannot hold both, so the credits stay above the links instead. */
-@media (min-width: 1440px) {
-  .ol-attribution {
-    /* Clear of the back button in the bottom-left corner of the map. */
-    left: 500px !important;
+    /* Bottom row of the map. The footer links move above them from `lg`, where
+       the two would otherwise share the row (`lg:bottom-[76px]` on the links). */
     bottom: 12px !important;
+    max-width: min(50ch, calc(100% - 30rem)) !important;
   }
 }
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -196,6 +196,15 @@
   }
 }
 
+/* From 1900 the bottom row fits both, so the footer links go back to it
+   (`min-[1900px]:bottom-3`) and the credits are bounded left of them: the links
+   end at x 961, and without the bound the credits would run under that. */
+@media (min-width: 1900px) {
+  .ol-attribution {
+    left: 969px !important;
+  }
+}
+
 .ol-attribution ul {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## What

Two small amendments to the map chrome, plus the placement fix from #226 rebased onto current `develop`.

**Map settings labels are clickable.** The `Regions layer` and `Country boundaries` switches carried no `id`, so their `<Label htmlFor="…">` pointed at nothing — clicking the text did nothing and only the 27px control worked. Both are wired now. Every row in the panel also gets `cursor-pointer`, so the label reads as part of the control rather than as static text.

**Tile credits move to the bottom row of the map.** The credits keep the box size they had; only their vertical position changes, from 40px up to the `bottom: 12px` row. What moves instead is the footer links, and only where the two would collide:

| viewport | footer links | tile credits |
| --- | --- | --- |
| < 768 | bottom row, right-anchored | 68px up, clear of the 60px toolbar |
| 768–1023 | bottom row, right-anchored | bottom row — the two never cross horizontally |
| 1024–1899 | stacked above the credits (`lg:bottom-[76px]`) | bottom row |
| ≥ 1900 | back on the bottom row, where they were | bottom row, bounded left of the links |

The measured geometry behind those thresholds, at height 900:

| element | position |
| --- | --- |
| footer links | `x 620–961`, 36px tall, `bottom: 12px` |
| legend | right-anchored, 448px wide (`max-w-md`) |
| credits text | ~900px on one line, wraps to 2–3 within its 50ch box |

The links end at x 961 and the credits are right-anchored 29rem in, so below 1900 the credits' box would run under the links — hence the stack in the middle band, and the `left: 969px` bound at 1900 and above.

Also included: the first commit (`da37d36`) is #226 cherry-picked unchanged — the dark veil behind the footer links over the light gray basemap, and the mobile offset that clears the 60px toolbar. **#226 can be closed in favour of this PR.**

## Test plan

- [x] `yarn check-types` clean
- [x] `yarn lint` clean (warnings are from an untracked scratch spec)
- [x] `e2e/basemap.spec.ts` — 13 passing, including 3 new: each label drives its own switch, and a basemap label selects that basemap
- [x] Measured placement at 1728 / 1512 / 1440 / 1280 and screenshots checked by eye at 1440 and 1280 — no text overlap
- [ ] Reviewer: the placement rules were re-cut after that measuring pass, so check each band — either side of 1024, either side of 1900, and mobile over the bottom toolbar

**Local test note:** run with `--workers=1`; parallel workers against one dev server make `page.goto` time out across the suite. Check nothing else holds port 3000 first — `reuseExistingServer` will happily test another project's app.

## Known limits

- The offsets are hardcoded pixel values tied to the sidebar, the links row (`620px`, `969px`) and the legend (`29rem`, matching `max-w-md`). If any of those widths change, these need changing with them.
- At 1024 and below with both the sidebar and the legend open, the map is ~128px wide and the credits wrap into a narrow column, partly under the sidebar. Pre-existing, unchanged here.
- The new label tests were not run against the pre-fix code, so they are coverage rather than a demonstrated regression catch.
