### PR TITLE
feat: add "Powered by Vizzuality and GILAB" to footer

### DIFF
--- a/src/components/footer/desktop.tsx
+++ b/src/components/footer/desktop.tsx
@@ -7,6 +7,7 @@ import { usePathname } from 'next/navigation';
 
 import { cn } from '@/lib/classnames';
 
+import PoweredBy from './powered-by';
 import SocialMedia from './social-media';
 
 export const FooterDesktop: FC = () => {
@@ -19,8 +20,8 @@ export const FooterDesktop: FC = () => {
         'px-5 md:px-5': pathname === '/',
       })}
     >
-      <div className="mx-8 flex w-full items-center justify-between xl:m-auto">
-        <div className="flex items-center">
+      <div className="mx-8 flex w-full items-center justify-between gap-x-6 xl:m-auto">
+        <div className="flex flex-col items-start gap-y-1 py-3">
           <a
             href="https://cordis.europa.eu/project/id/101059548"
             target="_blank"
@@ -36,10 +37,11 @@ export const FooterDesktop: FC = () => {
               alt="European Union Logo"
               style={{ height: 'auto' }}
             />
-            <span className="py-4 text-xs font-medium text-white-50 md:whitespace-nowrap">
+            <span className="text-xs font-medium text-white-50 md:whitespace-nowrap">
               Funded by the European Union
             </span>
           </a>
+          <PoweredBy />
         </div>
         <SocialMedia />
       </div>

--- a/src/components/footer/mobile.tsx
+++ b/src/components/footer/mobile.tsx
@@ -8,18 +8,19 @@ import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover
 
 import ShareSVG from '@/SVGS/share';
 
+import PoweredBy from './powered-by';
 import SocialMedia from './social-media';
 
 export const FooterMobile: FC = () => {
   return (
     <footer className="fixed bottom-0 z-[2000] flex w-full items-center justify-between space-y-2 bg-black-500 px-4">
-      <div className="flex-col space-y-9">
+      <div className="flex flex-col gap-y-1 py-3">
         <a
           href="https://cordis.europa.eu/project/id/101059548"
           target="_blank"
           rel="noopener noreferrer"
           title="Funded by the European Union"
-          className="flex space-x-2.5 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-green"
+          className="flex items-center space-x-2.5 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-green"
           data-test-id="OEMC-factsheet-link"
         >
           <Image
@@ -29,10 +30,11 @@ export const FooterMobile: FC = () => {
             alt="European Union Logo"
             style={{ height: 'auto' }}
           />
-          <span className="py-4 text-sm font-medium text-white-50 md:whitespace-nowrap">
+          <span className="text-sm font-medium text-white-50 md:whitespace-nowrap">
             Funded by the European Union
           </span>
         </a>
+        <PoweredBy size="md" />
       </div>
       <Popover>
         <PopoverTrigger

--- a/src/components/footer/powered-by.tsx
+++ b/src/components/footer/powered-by.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { FC } from 'react';
+
+import { cn } from '@/lib/classnames';
+
+const LINK_STYLES =
+  'rounded underline decoration-transparent underline-offset-2 transition-colors hover:decoration-inherit focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-green';
+
+export const PoweredBy: FC<{ size?: 'sm' | 'md' }> = ({ size = 'sm' }) => {
+  return (
+    <p
+      className={cn({
+        'font-medium text-white-50': true,
+        'text-xs': size === 'sm',
+        'text-sm': size === 'md',
+      })}
+      data-testid="powered-by"
+    >
+      Powered by{' '}
+      <a
+        href="https://www.vizzuality.com"
+        target="_blank"
+        rel="noopener noreferrer"
+        title="Vizzuality"
+        className={LINK_STYLES}
+        data-test-id="vizzuality-link"
+      >
+        Vizzuality
+      </a>{' '}
+      and{' '}
+      <a
+        href="https://gilab.rs"
+        target="_blank"
+        rel="noopener noreferrer"
+        title="GILAB"
+        className={LINK_STYLES}
+        data-test-id="gilab-link"
+      >
+        GILAB
+      </a>
+    </p>
+  );
+};
+
+export default PoweredBy;


### PR DESCRIPTION
Closes [OEMC-440](https://vizzuality.atlassian.net/browse/OEMC-440).

Adds a "Powered by Vizzuality and GILAB" credit to the footer, linking out to [vizzuality.com](https://www.vizzuality.com) and [gilab.rs](https://gilab.rs).

## What this implements

Three placements were prototyped and shared on the ticket; this PR implements **option C**, the one Angela picked: the partner names render as plain text links stacked under the "Funded by the European Union" line, styled like the rest of the footer.

The two logo-based options are dropped. Both partner logos are dark artwork and are effectively invisible against the dark footer, so they needed a light rounded surface that pulled a lot of attention for a credit line. Option C needs no surface, so the footer stays visually quiet and no new image assets are added.

## Changes

- `src/components/footer/powered-by.tsx` — new presentational component. Takes a `size` prop (`sm` for desktop, `md` for mobile) to match the surrounding footer type scale. Links open in a new tab with `rel="noopener noreferrer"` and carry a visible focus ring consistent with the existing EU funding link.
- `src/components/footer/desktop.tsx` — stacks the credit under the EU funding line, left-aligned with it. Moves the vertical padding from the funding `<span>` onto the wrapper so both lines share one padding box, and adds `gap-x-6` so the credit cannot collide with the social links.
- `src/components/footer/mobile.tsx` — same stacking. Also replaces `space-y-9` with `flex flex-col gap-y-1`, which the previous markup set without `flex-col` and so had no effect, and adds `items-center` to align the EU logo with its label.

Footer grows from 52px to 67px on desktop.

## Test plan

- [ ] Footer credit reads "Powered by Vizzuality and GILAB" under the EU funding line, on both the landing page and `/explore`
- [ ] Both links open the correct site in a new tab
- [ ] Keyboard tab order reaches both links and the focus ring is visible on each
- [ ] Check 768px, 1024px, 1440px and 1920px — credit stays left-aligned under the funding line and clear of the social links
- [ ] `yarn lint` and `yarn check-types` pass (both verified locally)

## Note on small viewports

The footer only swaps to the mobile layout between 768px and 1279px; below 768px it renders the desktop layout, which looks cramped at 390px. Pre-existing behaviour, not introduced here — worth a separate ticket.