### PR TITLE
perf: throttle WMS playback requests to prevent overlapping GeoServer tile rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Map controls style update to new designs [OEMC-355](https://vizzuality.atlassian.net/browse/OEMC-355)
+- WMS date changes during timeline playback are throttled against in-flight tiles, so GeoServer no longer renders tiles the frontend discards [OEMC-443](https://vizzuality.atlassian.net/browse/OEMC-443)
 
 
 ## v1.0.0-alpha.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Map controls style update to new designs [OEMC-355](https://vizzuality.atlassian.net/browse/OEMC-355)
-- WMS date changes during timeline playback are throttled against in-flight tiles, so GeoServer no longer renders tiles the frontend discards [OEMC-443](https://vizzuality.atlassian.net/browse/OEMC-443)
+- Timeline playback waits for the map tiles of the current date before advancing, keeping the slider and the map in sync and stopping GeoServer from rendering tiles the frontend discards [OEMC-443](https://vizzuality.atlassian.net/browse/OEMC-443)
 
 
 ## v1.0.0-alpha.6

--- a/src/app/store.tsx
+++ b/src/app/store.tsx
@@ -15,6 +15,14 @@ export const compareFunctionalityAtom = atom<boolean>(false);
 
 export const timeSeriesPlaybackAtom = atom<boolean>(true);
 
+/** Tiles in flight, keyed per WMS layer instance. Written by the map layers only. */
+export const mapTilesLoadingAtom = atom<Record<string, boolean>>({});
+
+/** True while any WMS layer still has tiles loading. Paces timeline playback. */
+export const areMapTilesLoadingAtom = atom<boolean>((get) =>
+  Object.values(get(mapTilesLoadingAtom)).some(Boolean)
+);
+
 export const nutsDataParamsAtom = atom<{ NUTS_ID: string; LAYER_ID: string }>({
   NUTS_ID: null,
   LAYER_ID: null,

--- a/src/components/map/layers/buffered-tile-wms.tsx
+++ b/src/components/map/layers/buffered-tile-wms.tsx
@@ -1,11 +1,14 @@
 'use client';
 
-import { FC, useCallback, useEffect, useRef } from 'react';
+import { FC, useCallback, useEffect, useId, useRef } from 'react';
 
+import { useSetAtom } from 'jotai';
 import TileLayer from 'ol/layer/Tile';
 import { unByKey } from 'ol/Observable';
 import TileWMS from 'ol/source/TileWMS';
 import { RLayerTileWMSProps, useOL } from 'rlayers';
+
+import { mapTilesLoadingAtom } from '@/app/store';
 
 import { WMS_CRS } from '../constants';
 
@@ -61,6 +64,29 @@ const BufferedTileWMS: FC<BufferedTileWMSProps> = ({
   const hasPendingDateRef = useRef(false);
   const appliedDateRef = useRef(date);
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const instanceId = useId();
+  const setTilesLoading = useSetAtom(mapTilesLoadingAtom);
+
+  /** Publish this layer's load state so timeline playback can wait for it. */
+  const publishLoading = useCallback(
+    (isLoading: boolean) => {
+      setTilesLoading((prev) =>
+        prev[instanceId] === isLoading ? prev : { ...prev, [instanceId]: isLoading }
+      );
+    },
+    [instanceId, setTilesLoading]
+  );
+
+  useEffect(() => {
+    return () =>
+      setTilesLoading((prev) => {
+        if (!(instanceId in prev)) return prev;
+        const next = { ...prev };
+        delete next[instanceId];
+        return next;
+      });
+  }, [instanceId, setTilesLoading]);
 
   const clearPendingTimeout = useCallback(() => {
     if (timeoutRef.current === null) return;
@@ -126,14 +152,18 @@ const BufferedTileWMS: FC<BufferedTileWMSProps> = ({
     hasPendingDateRef.current = false;
     pendingDateRef.current = undefined;
     appliedDateRef.current = dateRef.current;
+    publishLoading(false);
 
     const onTileLoadStart = () => {
       loadingTilesRef.current += 1;
+      publishLoading(true);
     };
 
     const onTileLoadSettled = () => {
       loadingTilesRef.current = Math.max(0, loadingTilesRef.current - 1);
-      if (loadingTilesRef.current === 0) flushPendingDate();
+      if (loadingTilesRef.current > 0) return;
+      publishLoading(false);
+      flushPendingDate();
     };
 
     const listenerKeys = [
@@ -175,10 +205,13 @@ const BufferedTileWMS: FC<BufferedTileWMSProps> = ({
 
     clearPendingTimeout();
     timeoutRef.current = setTimeout(() => {
+      // A tile load event never arrived: treat the source as idle so neither the pending
+      // date nor timeline playback stays blocked on it.
       loadingTilesRef.current = 0;
+      publishLoading(false);
       flushPendingDate();
     }, PENDING_DATE_TIMEOUT);
-  }, [date, applyDate, clearPendingTimeout, flushPendingDate]);
+  }, [date, applyDate, clearPendingTimeout, flushPendingDate, publishLoading]);
 
   useEffect(() => clearPendingTimeout, [clearPendingTimeout]);
 

--- a/src/components/map/layers/buffered-tile-wms.tsx
+++ b/src/components/map/layers/buffered-tile-wms.tsx
@@ -1,12 +1,19 @@
 'use client';
 
-import { FC, useEffect, useRef } from 'react';
+import { FC, useCallback, useEffect, useRef } from 'react';
 
 import TileLayer from 'ol/layer/Tile';
+import { unByKey } from 'ol/Observable';
 import TileWMS from 'ol/source/TileWMS';
 import { RLayerTileWMSProps, useOL } from 'rlayers';
 
 import { WMS_CRS } from '../constants';
+
+/**
+ * Upper bound for how long a date change waits for in-flight tiles. Guards against a tile
+ * whose load event never arrives, which would otherwise stall playback for this layer.
+ */
+const PENDING_DATE_TIMEOUT = 10000;
 
 interface BufferedTileWMSProps extends RLayerTileWMSProps {
   layerName: string;
@@ -17,6 +24,11 @@ interface BufferedTileWMSProps extends RLayerTileWMSProps {
 /**
  * WMS tile layer that uses OL's native `updateParams()` for date changes.
  * Old tiles stay visible as interim tiles until new ones load — no blink.
+ *
+ * Date changes are throttled against the tiles still in flight: OL does not cancel pending
+ * tile requests on `updateParams()`, so firing one per playback tick leaves GeoServer
+ * rendering tiles nobody will use. Requests that arrive while tiles are loading are
+ * coalesced into the latest date, applied once the source goes idle.
  */
 const BufferedTileWMS: FC<BufferedTileWMSProps> = ({
   url,
@@ -43,6 +55,36 @@ const BufferedTileWMS: FC<BufferedTileWMSProps> = ({
   dateRef.current = date;
   const onLayerChangeRef = useRef(onLayerChange);
   onLayerChangeRef.current = onLayerChange;
+
+  const loadingTilesRef = useRef(0);
+  const pendingDateRef = useRef<string | undefined>(undefined);
+  const hasPendingDateRef = useRef(false);
+  const appliedDateRef = useRef(date);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearPendingTimeout = useCallback(() => {
+    if (timeoutRef.current === null) return;
+    clearTimeout(timeoutRef.current);
+    timeoutRef.current = null;
+  }, []);
+
+  const applyDate = useCallback((nextDate: string | undefined) => {
+    appliedDateRef.current = nextDate;
+    layerRef.current?.getSource()?.updateParams({ DIM_DATE: nextDate });
+  }, []);
+
+  /** Apply the coalesced date, if any. Called when the source goes idle or the guard fires. */
+  const flushPendingDate = useCallback(() => {
+    clearPendingTimeout();
+    if (!hasPendingDateRef.current) return;
+
+    const nextDate = pendingDateRef.current;
+    hasPendingDateRef.current = false;
+    pendingDateRef.current = undefined;
+
+    if (nextDate === appliedDateRef.current) return;
+    applyDate(nextDate);
+  }, [applyDate, clearPendingTimeout]);
 
   // Create layer + source once; recreate only on url/layerName change
   useEffect(() => {
@@ -78,11 +120,35 @@ const BufferedTileWMS: FC<BufferedTileWMSProps> = ({
       properties,
     });
 
+    // The source starts fresh: no tiles in flight, nothing coalesced from the previous one
+    clearPendingTimeout();
+    loadingTilesRef.current = 0;
+    hasPendingDateRef.current = false;
+    pendingDateRef.current = undefined;
+    appliedDateRef.current = dateRef.current;
+
+    const onTileLoadStart = () => {
+      loadingTilesRef.current += 1;
+    };
+
+    const onTileLoadSettled = () => {
+      loadingTilesRef.current = Math.max(0, loadingTilesRef.current - 1);
+      if (loadingTilesRef.current === 0) flushPendingDate();
+    };
+
+    const listenerKeys = [
+      source.on('tileloadstart', onTileLoadStart),
+      source.on('tileloadend', onTileLoadSettled),
+      source.on('tileloaderror', onTileLoadSettled),
+    ];
+
     layerRef.current = layer;
     map.addLayer(layer);
     onLayerChangeRef.current?.(layer);
 
     return () => {
+      unByKey(listenerKeys);
+      clearPendingTimeout();
       map.removeLayer(layer);
       layerRef.current = null;
       onLayerChangeRef.current?.(null);
@@ -92,8 +158,29 @@ const BufferedTileWMS: FC<BufferedTileWMSProps> = ({
 
   // Date change → updateParams keeps old tiles visible until new ones load
   useEffect(() => {
-    layerRef.current?.getSource()?.updateParams({ DIM_DATE: date });
-  }, [date]);
+    if (date === appliedDateRef.current) return;
+
+    // Source idle: request straight away
+    if (loadingTilesRef.current === 0) {
+      clearPendingTimeout();
+      hasPendingDateRef.current = false;
+      pendingDateRef.current = undefined;
+      applyDate(date);
+      return;
+    }
+
+    // Tiles still loading: keep only the latest date and wait for the source to go idle
+    pendingDateRef.current = date;
+    hasPendingDateRef.current = true;
+
+    clearPendingTimeout();
+    timeoutRef.current = setTimeout(() => {
+      loadingTilesRef.current = 0;
+      flushPendingDate();
+    }, PENDING_DATE_TIMEOUT);
+  }, [date, applyDate, clearPendingTimeout, flushPendingDate]);
+
+  useEffect(() => clearPendingTimeout, [clearPendingTimeout]);
 
   useEffect(() => {
     layerRef.current?.setOpacity(opacity);

--- a/src/components/timeseries-comparative-layers/timeline.tsx
+++ b/src/components/timeseries-comparative-layers/timeline.tsx
@@ -3,13 +3,13 @@ import type { FC, MouseEvent } from 'react';
 
 import { TooltipPortal } from '@radix-ui/react-tooltip';
 import { LuCirclePlay, LuCirclePause } from 'react-icons/lu';
-import { useInterval } from 'usehooks-ts';
 
 import cn from '@/lib/classnames';
 
 import type { LayerParsed } from '@/types/layers';
 
 import { useSyncCompareLayersSettings, useSyncLayersSettings } from '@/hooks/sync-query';
+import { usePacedTimelineStep } from '@/hooks/timeline';
 
 import {
   IconTooltip,
@@ -19,7 +19,6 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip';
 
-const TIMEOUT_STEP_DURATION = 2500;
 const TICK_THRESHOLD = 20;
 
 const Timeline: FC<{
@@ -59,14 +58,13 @@ const Timeline: FC<{
     [layerId, compareLayers]
   );
 
-  useInterval(
-    () => {
-      if (!range?.length) return;
-      const nextRange = range[(range.indexOf(currentRange) + 1) % range.length];
-      void setLayers([{ ...layers?.[0], date: nextRange.value }]);
-    },
-    isPlaying ? TIMEOUT_STEP_DURATION : null
-  );
+  const goToNextDate = useCallback(() => {
+    if (!range?.length) return;
+    const nextRange = range[(range.indexOf(currentRange) + 1) % range.length];
+    void setLayers([{ ...layers?.[0], date: nextRange.value }]);
+  }, [range, currentRange, layers, setLayers]);
+
+  usePacedTimelineStep(isPlaying, goToNextDate);
 
   const handleTickClick = useCallback(
     (e: MouseEvent, value: string) => {

--- a/src/components/timeseries-layer/timeline.tsx
+++ b/src/components/timeseries-layer/timeline.tsx
@@ -3,13 +3,13 @@ import type { FC, MouseEvent } from 'react';
 
 import { TooltipPortal } from '@radix-ui/react-tooltip';
 import { LuCirclePlay, LuCirclePause } from 'react-icons/lu';
-import { useInterval } from 'usehooks-ts';
 
 import cn from '@/lib/classnames';
 
 import type { LayerParsed } from '@/types/layers';
 
 import { useSyncCompareLayersSettings, useSyncLayersSettings } from '@/hooks/sync-query';
+import { usePacedTimelineStep } from '@/hooks/timeline';
 
 import {
   IconTooltip,
@@ -19,7 +19,6 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip';
 
-const TIMEOUT_STEP_DURATION = 2500;
 const TICK_THRESHOLD = 20;
 
 const Timeline: FC<{
@@ -59,14 +58,13 @@ const Timeline: FC<{
     [layerId, compareLayers]
   );
 
-  useInterval(
-    () => {
-      if (!range?.length) return;
-      const nextRange = range[(range.indexOf(currentRange) + 1) % range.length];
-      void setLayers([{ ...layers?.[0], date: nextRange.value }]);
-    },
-    isPlaying ? TIMEOUT_STEP_DURATION : null
-  );
+  const goToNextDate = useCallback(() => {
+    if (!range?.length) return;
+    const nextRange = range[(range.indexOf(currentRange) + 1) % range.length];
+    void setLayers([{ ...layers?.[0], date: nextRange.value }]);
+  }, [range, currentRange, layers, setLayers]);
+
+  usePacedTimelineStep(isPlaying, goToNextDate);
 
   const handleTickClick = useCallback(
     (e: MouseEvent, value: string) => {

--- a/src/hooks/timeline.ts
+++ b/src/hooks/timeline.ts
@@ -1,0 +1,45 @@
+import { useEffect, useRef, useState } from 'react';
+
+import { useAtomValue } from 'jotai';
+
+import { areMapTilesLoadingAtom } from '@/app/store';
+
+export const TIMELINE_STEP_DURATION = 2500;
+
+/**
+ * Drives timeline playback on a fixed cadence that never runs ahead of the map: a step is
+ * held back while the WMS source still has tiles in flight, and fires as soon as it goes
+ * idle. The slider, the date label and the rendered tiles therefore stay on the same date
+ * instead of the map lagging behind the clock, and no date is skipped.
+ *
+ * Effective cadence is `max(TIMELINE_STEP_DURATION, tile load time)`.
+ */
+export function usePacedTimelineStep(isPlaying: boolean, step: () => void) {
+  const areMapTilesLoading = useAtomValue(areMapTilesLoadingAtom);
+
+  const stepRef = useRef(step);
+  stepRef.current = step;
+
+  const lastStepAtRef = useRef(0);
+  // Re-runs the scheduling effect after each step so the next one gets queued
+  const [stepCount, setStepCount] = useState(0);
+
+  useEffect(() => {
+    if (isPlaying) lastStepAtRef.current = Date.now();
+  }, [isPlaying]);
+
+  useEffect(() => {
+    if (!isPlaying || areMapTilesLoading) return;
+
+    // Time already spent loading counts towards the step, so a slow date does not also
+    // pay the full interval on top of its load time
+    const elapsed = Date.now() - lastStepAtRef.current;
+    const timeout = setTimeout(() => {
+      lastStepAtRef.current = Date.now();
+      stepRef.current();
+      setStepCount((count) => count + 1);
+    }, Math.max(0, TIMELINE_STEP_DURATION - elapsed));
+
+    return () => clearTimeout(timeout);
+  }, [isPlaying, areMapTilesLoading, stepCount]);
+}


### PR DESCRIPTION
### Overview

During timeline playback the map called `updateParams({ DIM_DATE })` on every tick (2.5s), regardless of whether the previous batch of tiles had finished. OpenLayers does not cancel in-flight tile requests on `updateParams()`, so GeoServer kept rendering tiles the frontend then discarded — wasted server work whenever the server ran slower than the playback interval.

**Two commits, and the second one is the important one.**

`perf: throttle WMS date changes against in-flight tiles` implements the ticket as written: `src/components/map/layers/buffered-tile-wms.tsx` counts in-flight tiles via `tileloadstart` / `tileloadend` / `tileloaderror`, and a date arriving while tiles load is stored and applied once the source goes idle, coalescing several ticks into one request.

On its own that fixes the server load but makes playback stutter. The Timeline advances the date every 2.5s unconditionally, so the clock and the map decouple: the slider and date label keep moving while the map holds and then jumps, the coalesced dates never render, and the value tooltip (which reads `date` from state, not from the source) shows a date the map is not displaying.

`perf: pace timeline playback on map tile readiness` fixes that by making the clock wait for the map:

- The WMS layers publish their in-flight tile state to `mapTilesLoadingAtom` (`src/app/store.tsx`), keyed per instance, derived into `areMapTilesLoadingAtom`.
- Both timelines now step through `usePacedTimelineStep` (`src/hooks/timeline.ts`) instead of a bare `useInterval`. A step is held while tiles are loading and fires as soon as they settle; time already spent loading counts towards the interval, so the cadence is `max(2.5s, tile load time)`.
- Slider, date label, tooltip and rendered tiles stay on the same date, and no date is skipped.

The layer-level coalescing stays in place as a safeguard for date changes that do not come from playback (manual scrubbing, tick clicks). Its 10s guard (`PENDING_DATE_TIMEOUT`) also releases the loading flag, so a tile whose load event never arrives cannot stall the timeline.

**Deviation from the ticket:** OEMC-443 asks for the change to be isolated to `buffered-tile-wms.tsx` with the Timeline untouched. That constraint is what produced the stutter — coalescing at the layer while the clock keeps running cannot keep the slider and the map on the same date. Noted on the ticket.

### Designs

N/A

### Testing instructions

1. Open `/explore`, activate a layer with a time dimension, open DevTools → Network, filter by `GetMap`.
2. Play the timeline. Requests should come in non-overlapping batches — a new `DIM_DATE` batch only starts after the previous one settles, no interleaving.
3. Throttle the network ("Slow 3G") and play again. Playback should slow down rather than skip: every date in the range still renders, the slider moves in step with the map, and no requests pile up.
4. Back on a fast connection, confirm the cadence is still ~2.5s per step.
5. Scrub the timeline manually and click individual ticks while tiles load — the map should end on the last date selected.
6. No visual regression: old tiles stay visible until new ones load (no blink).
7. Hover the map to open the value tooltip, then play — the tooltip value matches the date the map is showing.
8. Compare mode: enable it, confirm the main timeline is still paused and the comparative timeline plays with the same pacing.

Not verified at runtime by the author.

### Feature relevant tickets

[OEMC-443](https://vizzuality.atlassian.net/browse/OEMC-443)

---

## Checklist before submitting

- [x] Meaningful commits and code rebased on `develop`.
- [x] Update CHANGELOG
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist
