### PR TITLE
fix: let mobile drawer icons follow their trigger's colour

### DIFF
--- a/src/app/(landing)/geostories-mobile.tsx
+++ b/src/app/(landing)/geostories-mobile.tsx
@@ -55,9 +55,11 @@ export const GeostoriesGlobeMobile = () => {
       <DrawerTrigger
         aria-label="Open geostories list"
         data-testid="mobile-geostories-trigger"
-        className="focus:text-white data-[s] group shrink-0 rounded-full border border-accent-green p-3 text-accent-green hover:text-white-500 focus:outline-none active:bg-accent-green data-[state=open]:bg-accent-green data-[state=open]:text-white-500"
+        className="group shrink-0 rounded-full border border-accent-green p-3 text-accent-green hover:text-white-500 focus:outline-none focus-visible:text-white-500 focus-visible:ring-2 focus-visible:ring-accent-green active:bg-accent-green active:text-white-500 data-[state=open]:bg-accent-green data-[state=open]:text-white-500"
       >
-        <ListSVG className="h-6 w-6 text-accent-green" />
+        {/* No colour of its own: it inherits the trigger's, so hover, focus and
+            open states actually reach the icon. */}
+        <ListSVG className="h-6 w-6" />
       </DrawerTrigger>
       <DrawerContent
         data-testid="mobile-geostories-drawer"
@@ -65,10 +67,10 @@ export const GeostoriesGlobeMobile = () => {
       >
         <DrawerHeader className="flex flex-row items-center justify-between p-0">
           <DrawerTitle className="inline-flex text-white-500">Geostories</DrawerTitle>
-          <DrawerClose className="flex items-center gap-2.5  px-2 py-1 text-sm  focus:outline-none">
+          <DrawerClose className="group/geostories-close flex items-center gap-2.5  px-2 py-1 text-sm  focus:outline-none">
             <span>Collapse</span>
             <div className=" rounded-full bg-white-950 p-2">
-              <ChevronDown className="h-4 w-4 text-accent-green" />
+              <ChevronDown className="h-4 w-4 text-accent-green group-hover/geostories-close:text-white-500 group-focus/geostories-close:text-white-500" />
             </div>
           </DrawerClose>
         </DrawerHeader>

--- a/src/app/(landing)/live-updates-mobile.tsx
+++ b/src/app/(landing)/live-updates-mobile.tsx
@@ -21,9 +21,11 @@ export const LiveUpdatesGlobeMobile = () => {
       <DrawerTrigger
         aria-label="Open live updates feed"
         data-testid="mobile-live-updates-trigger"
-        className="focus:text-white data-[s] group/live-trigger shrink-0 rounded-full border border-accent-green p-3 text-accent-green hover:text-white-500 focus:outline-none active:bg-accent-green data-[state=open]:bg-accent-green data-[state=open]:text-white-500"
+        className="group/live-trigger shrink-0 rounded-full border border-accent-green p-3 text-accent-green hover:text-white-500 focus:outline-none focus-visible:text-white-500 focus-visible:ring-2 focus-visible:ring-accent-green active:bg-accent-green active:text-white-500 data-[state=open]:bg-accent-green data-[state=open]:text-white-500"
       >
-        <NewsSVG className="h-6 w-6 text-accent-green" />
+        {/* No colour of its own: it inherits the trigger's, so hover, focus and
+            open states actually reach the icon. */}
+        <NewsSVG className="h-6 w-6" />
       </DrawerTrigger>
       {/* The drawer is fixed to the bottom of the viewport, so it has to reserve
           the footer's own height — measured, because the mobile footer stacks

--- a/src/containers/filter-pill/index.tsx
+++ b/src/containers/filter-pill/index.tsx
@@ -6,7 +6,9 @@ export const FilterPill = ({ children }: { children?: React.ReactNode }) => (
   <Popover>
     <PopoverTrigger className="flex w-fit items-center space-x-4 rounded-full bg-white-500 px-5 py-2.5 font-satoshi text-sm font-medium text-black-500 hover:bg-accent-green focus:rounded-full disabled:pointer-events-none data-[state=closed]:bg-white-500 data-[state=open]:bg-accent-green">
       <span>Filter</span>
-      <FilterSVG className="text-black h-5 w-5" />
+      {/* `text-black` is not a class in this palette (`black` is a scale), so it
+          never applied: the icon inherits the trigger's colour instead. */}
+      <FilterSVG className="h-5 w-5" />
     </PopoverTrigger>
 
     <PopoverContent


### PR DESCRIPTION
## What

On the landing page's mobile layout, the geostories (list) and live-feed (news) drawer triggers changed colour on hover and when open, but their icons stayed green — the icons hardcoded `text-accent-green`, which outranked the button's `hover:` and `data-[state=open]:` colours. They now inherit.

## Changes

- `geostories-mobile.tsx`, `live-updates-mobile.tsx` — icons carry size only, no colour of their own.
- Same triggers: `focus:text-white` never applied (`white` is a scale in this palette, so `text-white` is not a class) — replaced with `focus-visible:text-white-500` plus a visible focus ring. Dropped a stray `data-[s]` class.
- Added `active:text-white-500` so the icon stays legible against the green pressed background.
- Geostories collapse chevron gained the hover/focus state the live-feed one already had.
- `filter-pill` — `text-black` was likewise a non-class (`black` is a scale); the icon now inherits the trigger's `text-black-500`, so it follows if that ever changes.

## Test plan

- [x] `yarn check-types` clean
- [x] `yarn lint` clean (except the pre-existing generated `next-env.d.ts` prettier error)
- [x] Measured computed `stroke` on both triggers at 900×800: rest `rgb(29, 237, 192)` → hover `rgb(255, 255, 230)` → open `rgb(255, 255, 230)`; both change on hover and on open
- [x] Filter pill icon fill follows the trigger (`rgb(9, 19, 29)` at rest and hover, matching `text-black-500`)
- [ ] Reviewer: eyeball the pressed (`:active`) state on a touch device